### PR TITLE
Expose and pass down alb_healthcheck_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ module "test" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_alb_healthcheck_path"></a> [alb\_healthcheck\_path](#input\_alb\_healthcheck\_path) | Path on the webserver that the elb will check to determine whether the instance is healthy or not. | `string` | `"/index.html"` | no |
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of instances in ASG. | `number` | `10` | no |
 | <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | Minimum number of instances in ASG. | `number` | `2` | no |
 | <a name="input_asg_subnets"></a> [asg\_subnets](#input\_asg\_subnets) | Auto Scaling Group Subnets. | `list(string)` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "alb_healthcheck_path" {
+  description = "Path on the webserver that the elb will check to determine whether the instance is healthy or not."
+  type        = string
+  default     = "/index.html"
+}
+
 variable "asg_min_size" {
   description = "Minimum number of instances in ASG."
   type        = number

--- a/website-pod.tf
+++ b/website-pod.tf
@@ -14,6 +14,7 @@ module "pod" {
   alb_name_prefix             = substr(var.service_name, 0, 6)
   alb_healthcheck_enabled     = true
   alb_healthcheck_port        = "traffic-port"
+  alb_healthcheck_path        = var.alb_healthcheck_path
   health_check_type           = "EC2"
   attach_tagret_group_to_asg  = false
   asg_min_size                = var.asg_min_size


### PR DESCRIPTION
alb_healthcheck_path is still used to check a target health by ECS.
