### PR TITLE
Workaround for re-creation of ECS service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ override.tf.json
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
 .terraform.lock.hcl
+test_data/test_module/terraform.tfvars
 tf.plan
 .idea
 /docs/_build/

--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,11 @@ resource "aws_ecs_service" "ecs" {
     container_name   = var.service_name
     container_port   = var.container_port
   }
+  capacity_provider_strategy {
+    base              = 1
+    capacity_provider = aws_ecs_capacity_provider.ecs.name
+    weight            = 100
+  }
   depends_on = [
     aws_iam_role.ecs_task_execution_role,
   ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ TEST_ACCOUNT = "303467602807"
 TEST_ROLE_ARN = "arn:aws:iam::303467602807:role/ecs-tester"
 DEFAULT_PROGRESS_INTERVAL = 10
 TRACE_TERRAFORM = False
-DESTROY_AFTER = True
+DESTROY_AFTER = False
 UBUNTU_CODENAME = "jammy"
 
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
It's a workaround of a bug
https://github.com/hashicorp/terraform-provider-aws/issues/22823

Terraform never converged and wanted to re-create the service.
```
Terraform used the selected providers to generate the following
execution plan. Resource actions are indicated with the following
symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.test.aws_ecs_service.ecs must be replaced
-/+ resource "aws_ecs_service" "ecs" {
      - health_check_grace_period_seconds  = 0 -> null
      ~ iam_role                           =
"/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS" -> (known
after apply)
      ~ id                                 =
"arn:aws:ecs:us-east-2:303467602807:service/test-terraform-aws-ecs/test-terraform-aws-ecs"
-> (known after apply)
      + launch_type                        = (known after apply)
        name                               = "test-terraform-aws-ecs"
      + platform_version                   = (known after apply)
      - propagate_tags                     = "NONE" -> null
      - tags                               = {} -> null
      ~ triggers                           = {} -> (known after apply)
        # (10 unchanged attributes hidden)

      - capacity_provider_strategy { # forces replacement
          - base              = 1 -> null
          - capacity_provider = "test-terraform-aws-ecs" -> null
          - weight            = 100 -> null
        }

      - deployment_circuit_breaker {
          - enable   = false -> null
          - rollback = false -> null
        }

      - deployment_controller {
          - type = "ECS" -> null
        }

        # (1 unchanged block hidden)
    }
```
