### PR TITLE
Upgrade website-pod module to 2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For usage see how the module is used in the using tests in `test_data/test_modul
 ```hcl
 module "test" {
   source  = "infrahouse/ecs/aws"
-  version = "~> 0.7"
+  version = "~> 0.8"
   providers = {
     aws     = aws
     aws.dns = aws

--- a/website-pod.tf
+++ b/website-pod.tf
@@ -8,7 +8,7 @@ module "pod" {
     aws     = aws
     aws.dns = aws.dns
   }
-  version                               = "~> 2.4"
+  version                               = "~> 2.5"
   service_name                          = var.service_name
   environment                           = var.environment
   alb_name_prefix                       = substr(var.service_name, 0, 6)


### PR DESCRIPTION
The 2.5 version changes how DNS records are created.
See https://github.com/infrahouse/terraform-aws-website-pod/pull/17
