### PR TITLE
Support task role in a container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ module "test" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_pod"></a> [pod](#module\_pod) | infrahouse/website-pod/aws | ~> 2.4 |
+| <a name="module_pod"></a> [pod](#module\_pod) | infrahouse/website-pod/aws | ~> 2.5 |
 
 ## Resources
 
@@ -102,6 +102,7 @@ module "test" {
 | <a name="input_task_environment_variables"></a> [task\_environment\_variables](#input\_task\_environment\_variables) | Environment variables passed down to a task. | <pre>list(object({<br>    name : string<br>    value : string<br>  }))</pre> | `[]` | no |
 | <a name="input_task_max_count"></a> [task\_max\_count](#input\_task\_max\_count) | Highest number of tasks to run | `number` | `10` | no |
 | <a name="input_task_min_count"></a> [task\_min\_count](#input\_task\_min\_count) | Lowest number of tasks to run | `number` | `1` | no |
+| <a name="input_task_role_arn"></a> [task\_role\_arn](#input\_task\_role\_arn) | Task Role ARN. The role will be assumed by a container. | `string` | `null` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Zone where DNS records will be created for the service and certificate validation. | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ resource "aws_ecs_task_definition" "ecs" {
     ]
   )
   execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
-  #  task_role_arn      = var.task_role_arn
+  task_role_arn      = var.task_role_arn
 }
 
 resource "aws_ecs_service" "ecs" {

--- a/test_data/test_module/datasources.tf
+++ b/test_data/test_module/datasources.tf
@@ -1,9 +1,11 @@
-data "aws_route53_zone" "cicd" {
-  name = var.test_zone
-}
-
+data "aws_caller_identity" "this" {}
+data "aws_region" "current" {}
 data "aws_availability_zones" "available" {
   state = "available"
+}
+
+data "aws_route53_zone" "cicd" {
+  name = var.test_zone
 }
 
 data "aws_ami" "ubuntu" {

--- a/test_data/test_module/main.tf
+++ b/test_data/test_module/main.tf
@@ -23,4 +23,5 @@ module "test" {
   internet_gateway_id           = module.service-network.internet_gateway_id
   task_desired_count            = 1
   container_healthcheck_command = "ls"
+  task_role_arn                 = aws_iam_role.task_role.arn
 }

--- a/test_data/test_module/task_role.tf
+++ b/test_data/test_module/task_role.tf
@@ -1,0 +1,51 @@
+data "aws_iam_policy_document" "task_role_assume" {
+  statement {
+    principals {
+      identifiers = [
+        "ecs-tasks.amazonaws.com"
+      ]
+      type = "Service"
+    }
+    actions = [
+      "sts:AssumeRole"
+    ]
+    condition {
+      test = "StringEquals"
+      values = [
+        data.aws_caller_identity.this.account_id
+      ]
+      variable = "aws:SourceAccount"
+    }
+    condition {
+      test = "ArnLike"
+      values = [
+        "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.this.account_id}:*"
+      ]
+      variable = "aws:SourceArn"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "task_role_permissions" {
+  statement {
+    actions = [
+      "s3:*"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "task_role" {
+  name_prefix = "task-"
+  policy      = data.aws_iam_policy_document.task_role_permissions.json
+}
+
+resource "aws_iam_role" "task_role" {
+  name_prefix        = "task-"
+  assume_role_policy = data.aws_iam_policy_document.task_role_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_role" {
+  policy_arn = aws_iam_policy.task_role.arn
+  role       = aws_iam_role.task_role.name
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ TEST_ACCOUNT = "303467602807"
 TEST_ROLE_ARN = "arn:aws:iam::303467602807:role/ecs-tester"
 DEFAULT_PROGRESS_INTERVAL = 10
 TRACE_TERRAFORM = False
-DESTROY_AFTER = False
+DESTROY_AFTER = True
 UBUNTU_CODENAME = "jammy"
 
 LOG = logging.getLogger(__name__)

--- a/variables.tf
+++ b/variables.tf
@@ -142,7 +142,8 @@ variable "task_min_count" {
   default     = 1
 }
 
-#variable "task_role_arn" {
-#  description = "Task Role ARN. The role will be assumed by a container."
-#  type        = string
-#}
+variable "task_role_arn" {
+  description = "Task Role ARN. The role will be assumed by a container."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
By default, an ECS container a.k.a. a task inherits permissions granted
to the instance profile.

`task_role_arn` variable allows to pass a custom role with specific
permissions.
