### PR TITLE
Put ECS into security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ module "test" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_pod"></a> [pod](#module\_pod) | infrahouse/website-pod/aws | ~> 2.5 |
+| <a name="module_pod"></a> [pod](#module\_pod) | infrahouse/website-pod/aws | ~> 2.6, >= 2.6.2 |
 
 ## Resources
 
@@ -65,6 +65,9 @@ module "test" {
 | [aws_ecs_task_definition.ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_iam_role.ecs_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.ecs_task_execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_security_group.backend_extra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_vpc_security_group_ingress_rule.backend_extra_reserved](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.backend_extra_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_ami.ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy.ecs-task-execution-role-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
@@ -72,6 +75,7 @@ module "test" {
 | [aws_iam_policy_document.instance_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_key_pair.ssh_key_pair](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/key_pair) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_subnet.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [cloudinit_config.ecs](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 
 ## Inputs

--- a/datasources.tf
+++ b/datasources.tf
@@ -82,3 +82,7 @@ data "aws_iam_policy" "ecs-task-execution-role-policy" {
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
+
+data "aws_subnet" "selected" {
+  id = var.asg_subnets[0]
+}

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,0 +1,33 @@
+resource "aws_security_group" "backend_extra" {
+  description = "Backend extrac security group for service ${var.service_name}"
+  name_prefix = "${var.service_name}-"
+  vpc_id      = data.aws_subnet.selected.vpc_id
+
+  tags = {
+    Name : "ECS ${var.service_name} backend"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "backend_extra_reserved" {
+  description       = "ECS reserved ports for service ${var.service_name}"
+  security_group_id = aws_security_group.backend_extra.id
+  from_port         = 2375
+  to_port           = 2376
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+  tags = {
+    Name = "ECS reserved"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "backend_extra_user" {
+  description       = "ECS user traffic ports for service ${var.service_name}"
+  security_group_id = aws_security_group.backend_extra.id
+  from_port         = 32768
+  to_port           = 65535
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+  tags = {
+    Name = "ECS user traffic"
+  }
+}

--- a/website-pod.tf
+++ b/website-pod.tf
@@ -8,7 +8,7 @@ module "pod" {
     aws     = aws
     aws.dns = aws.dns
   }
-  version                               = "~> 2.5"
+  version                               = "~> 2.6, >= 2.6.2"
   service_name                          = var.service_name
   environment                           = var.environment
   alb_name_prefix                       = substr(var.service_name, 0, 6)
@@ -22,6 +22,7 @@ module "pod" {
   instance_type                         = var.asg_instance_type
   asg_min_size                          = var.asg_min_size
   asg_max_size                          = var.asg_max_size
+  asg_scale_in_protected_instances      = "Refresh"
   subnets                               = var.load_balancer_subnets
   backend_subnets                       = var.asg_subnets
   zone_id                               = var.zone_id
@@ -35,6 +36,9 @@ module "pod" {
   internet_gateway_id                   = var.internet_gateway_id
   protect_from_scale_in                 = true # this is to allow ECS manage ASG instances
   autoscaling_target_cpu_load           = var.autoscaling_target_cpu_usage
+  extra_security_groups_backend = [
+    aws_security_group.backend_extra.id
+  ]
   tags = {
     Name : var.service_name
     AmazonECSManaged : true


### PR DESCRIPTION
The `infrahouse/website-pod/aws` module after version 2.6 creates
dedicated security groups for the load balancer and EC2 instances.
This commit uses the 2.6 and therefore runs the ECS infrastructure in
the dedicated security groups.

The ECS host machine needs extra ECS specific rules, that are defined in
the additional security group.

In theory, the change is backward compatible, but I will bump the major
version to make migrations safer.
