### PR TITLE
Add alb_healthcheck_interval and service_health_check_grace_period_seconds variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ module "test" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_alb_healthcheck_interval"></a> [alb\_healthcheck\_interval](#input\_alb\_healthcheck\_interval) | Number of seconds between checks | `number` | `5` | no |
 | <a name="input_alb_healthcheck_path"></a> [alb\_healthcheck\_path](#input\_alb\_healthcheck\_path) | Path on the webserver that the elb will check to determine whether the instance is healthy or not. | `string` | `"/index.html"` | no |
 | <a name="input_alb_healthcheck_response_code_matcher"></a> [alb\_healthcheck\_response\_code\_matcher](#input\_alb\_healthcheck\_response\_code\_matcher) | Range of http return codes that can match | `string` | `"200-299"` | no |
 | <a name="input_alb_idle_timeout"></a> [alb\_idle\_timeout](#input\_alb\_idle\_timeout) | The time in seconds that the connection is allowed to be idle. | `number` | `60` | no |
+| <a name="input_asg_health_check_grace_period"></a> [asg\_health\_check\_grace\_period](#input\_asg\_health\_check\_grace\_period) | ASG will wait up to this number of seconds for instance to become healthy | `number` | `300` | no |
 | <a name="input_asg_instance_type"></a> [asg\_instance\_type](#input\_asg\_instance\_type) | EC2 instances type | `string` | `"t3.micro"` | no |
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of instances in ASG. | `number` | `10` | no |
 | <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | Minimum number of instances in ASG. | `number` | `2` | no |
@@ -100,6 +102,7 @@ module "test" {
 | <a name="input_environment"></a> [environment](#input\_environment) | Name of environment. | `string` | `"development"` | no |
 | <a name="input_internet_gateway_id"></a> [internet\_gateway\_id](#input\_internet\_gateway\_id) | Internet gateway id. Usually created by 'infrahouse/service-network/aws' | `string` | n/a | yes |
 | <a name="input_load_balancer_subnets"></a> [load\_balancer\_subnets](#input\_load\_balancer\_subnets) | Load Balancer Subnets. | `list(string)` | n/a | yes |
+| <a name="input_service_health_check_grace_period_seconds"></a> [service\_health\_check\_grace\_period\_seconds](#input\_service\_health\_check\_grace\_period\_seconds) | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. | `number` | `null` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service name. | `string` | n/a | yes |
 | <a name="input_ssh_key_name"></a> [ssh\_key\_name](#input\_ssh\_key\_name) | ssh key name installed in ECS host instances. | `string` | n/a | yes |
 | <a name="input_task_desired_count"></a> [task\_desired\_count](#input\_task\_desired\_count) | Number of containers the ECS service will maintain. | `number` | `1` | no |

--- a/main.tf
+++ b/main.tf
@@ -72,25 +72,28 @@ resource "aws_ecs_task_definition" "ecs" {
 }
 
 resource "aws_ecs_service" "ecs" {
-  name            = var.service_name
-  cluster         = aws_ecs_cluster.ecs.id
-  task_definition = aws_ecs_task_definition.ecs.arn
-  desired_count   = var.task_desired_count
+  name                              = var.service_name
+  cluster                           = aws_ecs_cluster.ecs.id
+  task_definition                   = aws_ecs_task_definition.ecs.arn
+  desired_count                     = var.task_desired_count
+  health_check_grace_period_seconds = var.service_health_check_grace_period_seconds
+
   lifecycle {
     ignore_changes = [desired_count]
   }
-  #    iam_role        = aws_iam_role.task_role.arn
 
   load_balancer {
     target_group_arn = module.pod.target_group_arn
     container_name   = var.service_name
     container_port   = var.container_port
   }
+
   capacity_provider_strategy {
     base              = 1
     capacity_provider = aws_ecs_capacity_provider.ecs.name
     weight            = 100
   }
+
   depends_on = [
     aws_iam_role.ecs_task_execution_role,
   ]

--- a/test_data/test_module/client.tf
+++ b/test_data/test_module/client.tf
@@ -1,9 +1,10 @@
 module "jumphost" {
   source  = "infrahouse/jumphost/aws"
-  version = "1.2.0"
+  version = "~> 1.5"
   # insert the 4 required variables here
-  environment     = var.environment
-  keypair_name    = aws_key_pair.test.key_name
-  route53_zone_id = data.aws_route53_zone.cicd.zone_id
-  subnet_ids      = module.service-network.subnet_public_ids
+  environment      = var.environment
+  keypair_name     = aws_key_pair.test.key_name
+  route53_zone_id  = data.aws_route53_zone.cicd.zone_id
+  subnet_ids       = module.service-network.subnet_public_ids
+  route53_hostname = "jumphost-ecs"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -118,6 +118,12 @@ variable "service_name" {
   type        = string
 }
 
+variable "service_health_check_grace_period_seconds" {
+  description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647."
+  type        = number
+  default     = null
+}
+
 variable "ssh_key_name" {
   description = "ssh key name installed in ECS host instances."
   type        = string


### PR DESCRIPTION
Some services - I'm looking at you, kibana - take long time to start. Allow user to tune healthcheck timeouts, so the target group doesn't kill targets pre-maturely.
