### PR TITLE
Establish ECS dependency on ASG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,5 +96,6 @@ resource "aws_ecs_service" "ecs" {
 
   depends_on = [
     aws_iam_role.ecs_task_execution_role,
+    module.pod
   ]
 }


### PR DESCRIPTION
Why - when a user destroys the ECS module, Terraform tries to delete the ECS service before it deletes the ASG. That fails obviously.
The explicit dependency makes Terraform delete the ASG first.
