### PR TITLE
Remove dependency on aws_ecs_cluster.ecs

### DIFF
--- a/website-pod.tf
+++ b/website-pod.tf
@@ -46,7 +46,4 @@ module "pod" {
     Name : var.service_name
     AmazonECSManaged : true
   }
-  depends_on = [
-    aws_ecs_cluster.ecs
-  ]
 }


### PR DESCRIPTION
I had to remove a dependency on `aws_ecs_cluster.ecs. Why.
It broke creating a certificate for the website pod.

If the dependecy is specified then domain_validation_options are unknown during the plan even though we know the domain name:

```
  # module.httpd.module.pod.aws_acm_certificate.website will be created
  + resource "aws_acm_certificate" "website" {
      + arn                       = (known after apply)
      + domain_name               = (known after apply)
      + domain_validation_options = (known after apply)
```
This happens because Terraform can read the zone only after the ECS cluster is created i.e. after the "apply".

```
  # module.httpd.module.pod.data.aws_route53_zone.webserver_zone will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_route53_zone" "webserver_zone" {
```

Eventually, that leads to an error:
```
│ Error: Invalid for_each argument
│
│   on .terraform/modules/httpd.pod/ssl.tf line 13, in resource "aws_route53_record" "cert_validation":
│   13:   for_each = {
│   14:     for dvo in aws_acm_certificate.website.domain_validation_options : dvo.domain_name => {
│   15:       name   = dvo.resource_record_name
│   16:       record = dvo.resource_record_value
│   17:       type   = dvo.resource_record_type
│   18:     }
│   19:   }
│     ├────────────────
│     │ aws_acm_certificate.website.domain_validation_options is a set of object, known only after apply
│
│ The "for_each" map includes keys derived from resource attributes that
│ cannot be determined until apply, and so Terraform cannot determine the
│ full set of keys that will identify the instances of this resource.
```

Well, that means destroy will fail w/o the explicit dependency but at least the apply will succeed. I pick the latter option.
