### PR TITLE
Expose managed_draining as input variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ module "httpd" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_pod"></a> [pod](#module\_pod) | registry.infrahouse.com/infrahouse/website-pod/aws | ~> 2.6, >= 2.6.2 |
+| <a name="module_pod"></a> [pod](#module\_pod) | registry.infrahouse.com/infrahouse/website-pod/aws | 2.9.0 |
 
 ## Resources
 
@@ -143,7 +143,8 @@ module "httpd" {
 | <a name="input_extra_files"></a> [extra\_files](#input\_extra\_files) | Additional files to create on a host EC2 instance. | <pre>list(object({<br>    content     = string<br>    path        = string<br>    permissions = string<br>  }))</pre> | `[]` | no |
 | <a name="input_internet_gateway_id"></a> [internet\_gateway\_id](#input\_internet\_gateway\_id) | Internet gateway id. Usually created by 'infrahouse/service-network/aws' | `string` | n/a | yes |
 | <a name="input_load_balancer_subnets"></a> [load\_balancer\_subnets](#input\_load\_balancer\_subnets) | Load Balancer Subnets. | `list(string)` | n/a | yes |
-| <a name="input_managed_termination_protection"></a> [managed\_termination\_protection](#input\_managed\_termination\_protection) | Enables or disables container-aware termination of instances in the auto scaling group when scale-in happens | `bool` | `true` | no |
+| <a name="input_managed_draining"></a> [managed\_draining](#input\_managed\_draining) | Enables or disables a graceful shutdown of instances without disturbing workloads. | `bool` | `true` | no |
+| <a name="input_managed_termination_protection"></a> [managed\_termination\_protection](#input\_managed\_termination\_protection) | Enables or disables container-aware termination of instances in the auto scaling group when scale-in happens. | `bool` | `true` | no |
 | <a name="input_service_health_check_grace_period_seconds"></a> [service\_health\_check\_grace\_period\_seconds](#input\_service\_health\_check\_grace\_period\_seconds) | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 2147483647. | `number` | `null` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Service name. | `string` | n/a | yes |
 | <a name="input_ssh_key_name"></a> [ssh\_key\_name](#input\_ssh\_key\_name) | ssh key name installed in ECS host instances. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,9 @@ resource "aws_ecs_capacity_provider" "ecs" {
   name = var.service_name
 
   auto_scaling_group_provider {
-    auto_scaling_group_arn         = module.pod.asg_arn
-    managed_termination_protection = var.managed_termination_protection ? "ENABLED" : "DISABLED"
+    auto_scaling_group_arn        = module.pod.asg_arn
+    managed_termination_proection = var.managed_termination_protection ? "ENABLED" : "DISABLED"
+    managed_draining              = var.managed_draining ? "ENABLED" : "DISABLED"
 
     managed_scaling {
       maximum_scaling_step_size = 10

--- a/variables.tf
+++ b/variables.tf
@@ -135,8 +135,14 @@ variable "load_balancer_subnets" {
   type        = list(string)
 }
 
+variable "managed_draining" {
+  description = " Enables or disables a graceful shutdown of instances without disturbing workloads."
+  type        = bool
+  default     = true
+}
+
 variable "managed_termination_protection" {
-  description = "Enables or disables container-aware termination of instances in the auto scaling group when scale-in happens"
+  description = "Enables or disables container-aware termination of instances in the auto scaling group when scale-in happens."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
Correction. My previous commit message was actually about
managed_draining, not managed_termination_protection. Keep both of them
in case either of them needed. Default behaviour is preserved.
