### PR TITLE
Prevent adding the same rule to SG

### DIFF
--- a/website-pod.tf
+++ b/website-pod.tf
@@ -4,7 +4,7 @@ data "aws_key_pair" "ssh_key_pair" {
 
 module "pod" {
   source  = "registry.infrahouse.com/infrahouse/website-pod/aws"
-  version = "3.3.7"
+  version = "3.3.8"
   providers = {
     aws     = aws
     aws.dns = aws.dns


### PR DESCRIPTION
When service cidr block matches user provided CIDR block for SSH, don't
add a duplicate rule.
