### PR TITLE
Upgrade website-pod to 4.1.0

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -2,7 +2,7 @@ resource "aws_iam_role" "ecs_task_execution_role" {
   # expected length of name_prefix to be in the range (1 - 38)
   name_prefix        = substr("${var.service_name}TaskExecutionRole", 0, 38)
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
-  tags               = local.tags
+  tags               = local.default_module_tags
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {

--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,10 @@ locals {
   module_version = "3.6.1"
 
   module_name = "infrahouse/ecs/aws"
-  tags = {
+  default_module_tags = {
+    environment : var.environment
+    service : var.service_name
+    account : data.aws_caller_identity.current.account_id
     created_by_module : local.module_name
     module_version = local.module_version
   }

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ resource "aws_ecs_capacity_provider" "ecs" {
       instance_warmup_period = 300
     }
   }
-  tags = local.tags
+  tags = local.default_module_tags
 }
 
 resource "aws_ecs_cluster_capacity_providers" "ecs" {
@@ -36,7 +36,7 @@ resource "aws_ecs_cluster" "ecs" {
     name  = "containerInsights"
     value = "enabled"
   }
-  tags = local.tags
+  tags = local.default_module_tags
 }
 
 resource "aws_ecs_task_definition" "ecs" {
@@ -97,7 +97,7 @@ resource "aws_ecs_task_definition" "ecs" {
       host_path = volume.value.host_path
     }
   }
-  tags = local.tags
+  tags = local.default_module_tags
 }
 
 resource "aws_ecs_service" "ecs" {
@@ -143,7 +143,7 @@ resource "aws_ecs_service" "ecs" {
       instance_role_policy_name : module.pod.instance_role_policy_name
       instance_role_policy_attachment : module.pod.instance_role_policy_attachment
     },
-    local.tags
+    local.default_module_tags
   )
   timeouts {
     delete = "10m"

--- a/website-pod.tf
+++ b/website-pod.tf
@@ -4,7 +4,7 @@ data "aws_key_pair" "ssh_key_pair" {
 
 module "pod" {
   source  = "registry.infrahouse.com/infrahouse/website-pod/aws"
-  version = "4.0.0"
+  version = "4.1.0"
   providers = {
     aws     = aws
     aws.dns = aws.dns


### PR DESCRIPTION
The 4.1.0 version tags instances and other indirectly created resources.
