### PR TITLE
Add variable secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ module "httpd" {
 | <a name="input_task_max_count"></a> [task\_max\_count](#input\_task\_max\_count) | Highest number of tasks to run | `number` | `10` | no |
 | <a name="input_task_min_count"></a> [task\_min\_count](#input\_task\_min\_count) | Lowest number of tasks to run | `number` | `1` | no |
 | <a name="input_task_role_arn"></a> [task\_role\_arn](#input\_task\_role\_arn) | Task Role ARN. The role will be assumed by a container. | `string` | `null` | no |
+| <a name="input_task_secrets"></a> [task\_secrets](#input\_task\_secrets) | Secrets to pass to a container. A `name` will be the environment variable. valueFrom is a secret ARN. | <pre>list(<br/>    object(<br/>      {<br/>        name : string<br/>        valueFrom : string<br/>      }<br/>    )<br/>  )</pre> | `[]` | no |
 | <a name="input_users"></a> [users](#input\_users) | A list of maps with user definitions according to the cloud-init format | `any` | `null` | no |
 | <a name="input_zone_id"></a> [zone\_id](#input\_zone\_id) | Zone where DNS records will be created for the service and certificate validation. | `string` | n/a | yes |
 
@@ -205,3 +206,5 @@ module "httpd" {
 | <a name="output_dns_hostnames"></a> [dns\_hostnames](#output\_dns\_hostnames) | DNS hostnames where the ECS service is available. |
 | <a name="output_load_balancer_dns_name"></a> [load\_balancer\_dns\_name](#output\_load\_balancer\_dns\_name) | Load balancer DNS name. |
 | <a name="output_service_arn"></a> [service\_arn](#output\_service\_arn) | ECS service ARN. |
+| <a name="output_task_execution_role_arn"></a> [task\_execution\_role\_arn](#output\_task\_execution\_role\_arn) | Task execution role is a role that ECS agent gets. |
+| <a name="output_task_execution_role_name"></a> [task\_execution\_role\_name](#output\_task\_execution\_role\_name) | Task execution role is a role that ECS agent gets. |

--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,7 @@ resource "aws_ecs_task_definition" "ecs" {
           }
           logConfiguration = local.log_configuration
           environment      = var.task_environment_variables
+          secrets          = var.task_secrets
           mountPoints = [
             for name, def in merge(var.task_efs_volumes, var.task_local_volumes) : {
               sourceVolume : name

--- a/outputs.tf
+++ b/outputs.tf
@@ -32,3 +32,13 @@ output "dns_hostnames" {
   description = "DNS hostnames where the ECS service is available."
   value       = [for h in var.dns_names : trimprefix(join(".", [h, data.aws_route53_zone.this.name]), ".")]
 }
+
+output "task_execution_role_name" {
+  description = "Task execution role is a role that ECS agent gets."
+  value       = aws_iam_role.ecs_task_execution_role.name
+}
+
+output "task_execution_role_arn" {
+  description = "Task execution role is a role that ECS agent gets."
+  value       = aws_iam_role.ecs_task_execution_role.arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -212,6 +212,20 @@ variable "ssh_cidr_block" {
   default     = null
 }
 
+variable "task_secrets" {
+  description = "Secrets to pass to a container. A `name` will be the environment variable. valueFrom is a secret ARN."
+  type = list(
+    object(
+      {
+        name : string
+        valueFrom : string
+      }
+    )
+  )
+  sensitive = true
+  default   = []
+}
+
 variable "task_desired_count" {
   description = "Number of containers the ECS service will maintain."
   type        = number


### PR DESCRIPTION
It allows to pass secret values to containers as environment variables.

```
  task_secrets = [
    {
      name : "FAKE_API_KEY"
      valueFrom : module.some-secret.secret_arn
    }
  ]

```

If a secret is created with the InfraHouse Secrets module, make sure
the Task Execution Role has permission to read the secret.

```
module "some-secret" {
  source             = "registry.infrahouse.com/infrahouse/secret/aws"
  version            = "~> 0.7"
  secret_description = "Test secret"
  secret_name_prefix = "some-secret"
  secret_value       = "qwerty"
  readers = [
    module.httpd.task_execution_role_arn
  ]
}
```
