### PR TITLE
Refactor CloudWatch Agent interface

### DIFF
--- a/assets/cloudwatch_agent_config.tftmpl
+++ b/assets/cloudwatch_agent_config.tftmpl
@@ -1,0 +1,24 @@
+{
+  "agent": {
+    "logfile": "/var/log/amazon-cloudwatch-agent.log",
+    "debug": false
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/messages",
+            "log_group_name": "${syslog_group_name}",
+            "log_stream_name": "{local_hostname}"
+          },
+          {
+            "file_path": "/var/log/dmesg",
+            "log_group_name": "${dmesg_group_name}",
+            "log_stream_name": "{local_hostname}"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -10,3 +10,29 @@ resource "aws_cloudwatch_log_group" "ecs" {
     }
   )
 }
+
+resource "aws_cloudwatch_log_group" "ecs_ec2_syslog" {
+  count             = var.enable_cloudwatch_logs ? 1 : 0
+  name              = "${local.cloudwatch_group}-syslog"
+  retention_in_days = var.cloudwatch_log_group_retention
+  tags = merge(
+    local.default_module_tags,
+    {
+      VantaContainsUserData : false
+      VantaContainsEPHI : false
+    }
+  )
+}
+
+resource "aws_cloudwatch_log_group" "ecs_ec2_dmesg" {
+  count             = var.enable_cloudwatch_logs ? 1 : 0
+  name              = "${local.cloudwatch_group}-dmesg"
+  retention_in_days = var.cloudwatch_log_group_retention
+  tags = merge(
+    local.default_module_tags,
+    {
+      VantaContainsUserData : false
+      VantaContainsEPHI : false
+    }
+  )
+}

--- a/cloudwatch_agent.tf
+++ b/cloudwatch_agent.tf
@@ -1,18 +1,21 @@
-resource "aws_iam_role" "cloudwatch_agent_task_role" {
-  count       = var.enable_cloudwatch_agent ? 1 : 0
-  name_prefix = format("%s-cw-agent-", var.service_name)
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          Service = "ecs-tasks.amazonaws.com"
-        }
-      }
+data "aws_iam_policy_document" "cloudwatch_agent_task_role_assume_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole"
     ]
-  })
+    effect = "Allow"
+    principals {
+      identifiers = [
+        "ecs-tasks.amazonaws.com"
+      ]
+      type = "Service"
+    }
+  }
+}
+resource "aws_iam_role" "cloudwatch_agent_task_role" {
+  count              = var.enable_cloudwatch_logs ? 1 : 0
+  name_prefix        = format("%s-cw-agent-", var.service_name)
+  assume_role_policy = data.aws_iam_policy_document.cloudwatch_agent_task_role_assume_policy.json
   tags = merge(
     local.default_module_tags,
     {
@@ -23,40 +26,45 @@ resource "aws_iam_role" "cloudwatch_agent_task_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "cloudwatch_policy_attachment" {
-  count      = var.enable_cloudwatch_agent ? 1 : 0
+  count      = var.enable_cloudwatch_logs ? 1 : 0
   role       = aws_iam_role.cloudwatch_agent_task_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_task_execution_policy" {
-  count      = var.enable_cloudwatch_agent ? 1 : 0
+  count      = var.enable_cloudwatch_logs ? 1 : 0
   role       = aws_iam_role.cloudwatch_agent_task_role[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
 resource "aws_ecs_task_definition" "cloudwatch_agent" {
-  count              = var.enable_cloudwatch_agent ? 1 : 0
+  count              = var.enable_cloudwatch_logs ? 1 : 0
   family             = format("%s-cw-agent-daemon", var.service_name)
   task_role_arn      = aws_iam_role.cloudwatch_agent_task_role[0].arn
   execution_role_arn = aws_iam_role.cloudwatch_agent_task_role[0].arn
 
-  container_definitions = jsonencode([{
-    name      = "cloudwatch-agent"
-    image     = var.cloudwatch_agent_image
-    memory    = var.cloudwatch_agent_container_resources.memory
-    cpu       = var.cloudwatch_agent_container_resources.cpu
-    essential = true
-    mountPoints = [{
-      sourceVolume  = "log-volume"
-      containerPath = "/var/log"
-      },
+  container_definitions = jsonencode(
+    [
       {
-        sourceVolume  = "config-volume"
-        containerPath = "/etc/cwagentconfig"
-        readOnly      = true
+        name      = "cloudwatch-agent"
+        image     = var.cloudwatch_agent_image
+        memory    = local.cloudwatch_agent_container_resources.memory
+        cpu       = local.cloudwatch_agent_container_resources.cpu
+        essential = true
+        mountPoints = [
+          {
+            sourceVolume  = "log-volume"
+            containerPath = "/var/log"
+          },
+          {
+            sourceVolume  = "config-volume"
+            containerPath = "/etc/cwagentconfig"
+            readOnly      = true
+          }
+        ]
       }
     ]
-  }])
+  )
 
   volume {
     name      = "log-volume"
@@ -65,7 +73,7 @@ resource "aws_ecs_task_definition" "cloudwatch_agent" {
 
   volume {
     name      = "config-volume"
-    host_path = var.cloudwatch_agent_config_path
+    host_path = "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
   }
   tags = merge(
     local.default_module_tags,
@@ -77,7 +85,7 @@ resource "aws_ecs_task_definition" "cloudwatch_agent" {
 }
 
 resource "aws_ecs_service" "cloudwatch_agent_service" {
-  count               = var.enable_cloudwatch_agent ? 1 : 0
+  count               = var.enable_cloudwatch_logs ? 1 : 0
   name                = "cloudwatch-agent-daemon"
   cluster             = aws_ecs_cluster.ecs.id
   task_definition     = aws_ecs_task_definition.cloudwatch_agent[0].arn

--- a/datasources.tf
+++ b/datasources.tf
@@ -58,6 +58,19 @@ data "cloudinit_config" "ecs" {
                     )
                   }
                 ],
+                var.enable_cloudwatch_logs == true ? [
+                  {
+                    path : local.cloudwatch_agent_config_path
+                    permissions : "0644"
+                    content : templatefile(
+                      "${path.module}/assets/cloudwatch_agent_config.tftmpl",
+                      {
+                        syslog_group_name : aws_cloudwatch_log_group.ecs_ec2_syslog[0].name
+                        dmesg_group_name : aws_cloudwatch_log_group.ecs_ec2_dmesg[0].name
+                      }
+                    )
+                  }
+                ] : [],
                 var.extra_files
               )
             },
@@ -142,4 +155,8 @@ data "aws_iam_policy_document" "ecs_cloudwatch_logs_policy" {
 data "aws_route53_zone" "this" {
   zone_id  = var.zone_id
   provider = aws.dns
+}
+
+data "aws_ec2_instance_type" "backend" {
+  instance_type = var.asg_instance_type
 }

--- a/ssh.tf
+++ b/ssh.tf
@@ -1,0 +1,16 @@
+resource "tls_private_key" "rsa" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "ecs" {
+  key_name_prefix = "${var.service_name}-"
+  public_key      = tls_private_key.rsa.public_key_openssh
+  tags = merge(
+    local.default_module_tags,
+    {
+      VantaContainsUserData : false
+      VantaContainsEPHI : false
+    }
+  )
+}

--- a/tcp-pod.tf
+++ b/tcp-pod.tf
@@ -18,15 +18,15 @@ module "tcp-pod" {
   health_check_type                = "EC2"
   attach_target_group_to_asg       = false
   instance_type                    = var.asg_instance_type
-  asg_min_size                     = var.asg_min_size
-  asg_max_size                     = var.asg_max_size
+  asg_min_size                     = local.asg_min_size
+  asg_max_size                     = local.asg_max_size
   asg_scale_in_protected_instances = "Refresh"
   subnets                          = var.load_balancer_subnets
   backend_subnets                  = var.asg_subnets
   zone_id                          = var.zone_id
   dns_a_records                    = var.dns_names
   ami                              = var.ami_id == null ? data.aws_ami.ecs.image_id : var.ami_id
-  key_pair_name                    = data.aws_key_pair.ssh_key_pair.key_name
+  key_pair_name                    = var.ssh_key_name != null ? var.ssh_key_name : aws_key_pair.ecs.key_name
   target_group_port                = var.container_port
   userdata                         = data.cloudinit_config.ecs.rendered
   instance_profile_permissions     = data.aws_iam_policy_document.instance_policy.json

--- a/test_data/httpd/main.tf
+++ b/test_data/httpd/main.tf
@@ -32,15 +32,14 @@ module "httpd" {
   docker_image                  = "httpd"
   container_port                = 80
   service_name                  = var.service_name
-  ssh_key_name                  = aws_key_pair.black-mbp.key_name
   zone_id                       = data.aws_route53_zone.cicd.zone_id
   internet_gateway_id           = var.internet_gateway_id
-  task_desired_count            = 1
-  asg_max_size                  = 1
-  asg_min_size                  = 1
   container_healthcheck_command = "ls"
   task_role_arn                 = aws_iam_role.task_role.arn
+  enable_cloudwatch_logs        = true
   vanta_contains_user_data      = true
+  task_min_count                = 20
+  task_max_count                = 40
   task_secrets = [
     {
       name : "FAKE_API_KEY"

--- a/variables.tf
+++ b/variables.tf
@@ -23,15 +23,15 @@ variable "asg_health_check_grace_period" {
 }
 
 variable "asg_min_size" {
-  description = "Minimum number of instances in ASG."
+  description = "Minimum number of instances in ASG. By default, the number of subnets."
   type        = number
-  default     = 2
+  default     = null
 }
 
 variable "asg_max_size" {
-  description = "Maximum number of instances in ASG."
+  description = "Maximum number of instances in ASG. By default, it's calculated based on number of tasks and their memory requirements."
   type        = number
-  default     = 10
+  default     = null
 }
 
 variable "asg_subnets" {
@@ -63,32 +63,14 @@ variable "autoscaling_target" {
   default     = null
 }
 
-variable "cloudwatch_agent_config_path" {
-  description = "Path to cloudwatch agent config on host fs"
-  type        = string
-  default     = ""
-}
-
 variable "cloudwatch_agent_image" {
   description = "Cloudwatch agent image"
   type        = string
-  default     = "amazon/cloudwatch-agent:1.300037.1b602"
-}
-
-variable "cloudwatch_agent_container_resources" {
-  description = "Resources for cloudwatch agent container"
-  type = object({
-    cpu    = number
-    memory = number
-  })
-  default = {
-    cpu    = 128
-    memory = 256
-  }
+  default     = "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest"
 }
 
 variable "cloudwatch_log_group" {
-  description = "CloudWatch log group to create and use. Default: /ecs/{name}-{environment}"
+  description = "CloudWatch log group to create and use. Default: /ecs/{var.environment}/{var.service_name}"
   type        = string
   default     = null
 }
@@ -97,12 +79,6 @@ variable "cloudwatch_log_group_retention" {
   description = "Number of days you want to retain log events in the log group."
   default     = 90
   type        = number
-}
-
-variable "enable_cloudwatch_agent" {
-  description = "Add cloudwatch agent service to ECS cluster with DAEMON type"
-  type        = bool
-  default     = false
 }
 
 variable "enable_cloudwatch_logs" {
@@ -268,6 +244,7 @@ variable "service_health_check_grace_period_seconds" {
 variable "ssh_key_name" {
   description = "ssh key name installed in ECS host instances."
   type        = string
+  default     = null
 }
 
 variable "ssh_cidr_block" {

--- a/website-pod.tf
+++ b/website-pod.tf
@@ -1,11 +1,7 @@
-data "aws_key_pair" "ssh_key_pair" {
-  key_name = var.ssh_key_name
-}
-
 module "pod" {
   count   = var.lb_type == "alb" ? 1 : 0
   source  = "registry.infrahouse.com/infrahouse/website-pod/aws"
-  version = "4.8.2"
+  version = "4.8.3"
   providers = {
     aws     = aws
     aws.dns = aws.dns
@@ -26,8 +22,8 @@ module "pod" {
   health_check_type                     = "EC2"
   attach_tagret_group_to_asg            = false
   instance_type                         = var.asg_instance_type
-  asg_min_size                          = var.asg_min_size
-  asg_max_size                          = var.asg_max_size
+  asg_min_size                          = local.asg_min_size
+  asg_max_size                          = local.asg_max_size
   asg_scale_in_protected_instances      = "Refresh"
   subnets                               = var.load_balancer_subnets
   backend_subnets                       = var.asg_subnets
@@ -35,7 +31,7 @@ module "pod" {
   dns_a_records                         = var.dns_names
   assume_dns                            = var.assume_dns
   ami                                   = var.ami_id == null ? data.aws_ami.ecs.image_id : var.ami_id
-  key_pair_name                         = data.aws_key_pair.ssh_key_pair.key_name
+  key_pair_name                         = var.ssh_key_name != null ? var.ssh_key_name : aws_key_pair.ecs.key_name
   target_group_port                     = var.container_port
   userdata                              = data.cloudinit_config.ecs.rendered
   instance_profile_permissions          = data.aws_iam_policy_document.instance_policy.json


### PR DESCRIPTION
* Move most of cloudwatch agent resources inside the module. What was
  accepted as a variable, now created in the module.
* When the `enable_cloudwatch_logs` is set to true, CloudWatch Agent
  will collect `/var/log/messages` (syslog goes here on Amazon OS),
  `/var/log/dmesg`, and application output i.e. `docker logs`
* IMDSv2 is required, the CloudWatch Agent can't read the instance
  metadata, so the log stream is a hostname of a container running
  the CloudWatch Agent. Not sure if we ever need instance_id
  as the stream name. Will see.
* CloudWatch Agent logs are collected on a host instance in
  `/var/log/amazon-cloudwatch-agent.log`.
* Autoscaling group size is calculated by default, unless explicitly
  specified. The rule goes like this.
  Min size:
  * Number of ASG subnets. The idea is to have a host in every subnet
    (~AZ)
  Max size is picked as the maximum of three numbers
  * Number of EC2 instances with enough RAM to host `var.task_max_count`
    number of tasks.
  * Number of EC2 instances with enough CPU to host `var.task_max_count`
    number of tasks.
  * The minimum size of the ASG plus one.
* The SSH key is optional and generated if not specified.
