### PR TITLE
Remove attribute sensitive from task_secrets and task_environment_variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -275,8 +275,7 @@ variable "task_secrets" {
       }
     )
   )
-  sensitive = true
-  default   = []
+  default = []
 }
 
 variable "task_desired_count" {
@@ -295,8 +294,7 @@ variable "task_environment_variables" {
       }
     )
   )
-  sensitive = true
-  default   = []
+  default = []
 }
 
 variable "task_ipc_mode" {


### PR DESCRIPTION
`task_secrets` don't contain secrets, they contain ARN of secrets.
`task_environment_variables` should not contain secret values.
