### PR TITLE
feat: add cleanup_ecs_task_definitions fixture to prevent task definition accumulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ module "httpd" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.5 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.56 |
-| <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | ~> 2.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.56, < 7.0 |
 
 ## Providers
 
@@ -94,15 +93,15 @@ module "httpd" {
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.56, < 7.0 |
 | <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | >= 5.56, < 7.0 |
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | ~> 2.3 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_pod"></a> [pod](#module\_pod) | registry.infrahouse.com/infrahouse/website-pod/aws | 4.10.0 |
-| <a name="module_tcp-pod"></a> [tcp-pod](#module\_tcp-pod) | registry.infrahouse.com/infrahouse/tcp-pod/aws | 0.3.0 |
+| <a name="module_pod"></a> [pod](#module\_pod) | registry.infrahouse.com/infrahouse/website-pod/aws | 5.8.2 |
+| <a name="module_tcp-pod"></a> [tcp-pod](#module\_tcp-pod) | registry.infrahouse.com/infrahouse/tcp-pod/aws | 0.6.0 |
 
 ## Resources
 
@@ -224,12 +223,15 @@ module "httpd" {
 
 | Name | Description |
 |------|-------------|
+| <a name="output_acm_certificate_arn"></a> [acm\_certificate\_arn](#output\_acm\_certificate\_arn) | ARN of the ACM certificate used by the load balancer |
 | <a name="output_asg_arn"></a> [asg\_arn](#output\_asg\_arn) | Autoscaling group ARN created for the ECS service. |
 | <a name="output_asg_name"></a> [asg\_name](#output\_asg\_name) | Autoscaling group name created for the ECS service. |
 | <a name="output_backend_security_group"></a> [backend\_security\_group](#output\_backend\_security\_group) | Security group of backend. |
 | <a name="output_dns_hostnames"></a> [dns\_hostnames](#output\_dns\_hostnames) | DNS hostnames where the ECS service is available. |
 | <a name="output_load_balancer_arn"></a> [load\_balancer\_arn](#output\_load\_balancer\_arn) | Load balancer ARN. |
 | <a name="output_load_balancer_dns_name"></a> [load\_balancer\_dns\_name](#output\_load\_balancer\_dns\_name) | Load balancer DNS name. |
+| <a name="output_load_balancer_security_groups"></a> [load\_balancer\_security\_groups](#output\_load\_balancer\_security\_groups) | Security groups associated with the load balancer |
 | <a name="output_service_arn"></a> [service\_arn](#output\_service\_arn) | ECS service ARN. |
+| <a name="output_ssl_listener_arn"></a> [ssl\_listener\_arn](#output\_ssl\_listener\_arn) | SSL listener ARN |
 | <a name="output_task_execution_role_arn"></a> [task\_execution\_role\_arn](#output\_task\_execution\_role\_arn) | Task execution role is a role that ECS agent gets. |
 | <a name="output_task_execution_role_name"></a> [task\_execution\_role\_name](#output\_task\_execution\_role\_name) | Task execution role is a role that ECS agent gets. |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pytest-infrahouse ~= 0.9
+pytest-infrahouse ~= 0.17, >= 0.17.1
 infrahouse-core ~= 0.17

--- a/test_data/httpd/outputs.tf
+++ b/test_data/httpd/outputs.tf
@@ -9,3 +9,7 @@ output "jumphost_hostname" {
 output "dns_hostnames" {
   value = module.httpd.dns_hostnames
 }
+
+output "service_name" {
+  value = var.service_name
+}

--- a/test_data/httpd_autoscaling/outputs.tf
+++ b/test_data/httpd_autoscaling/outputs.tf
@@ -5,3 +5,7 @@ output "zone_id" {
 output "jumphost_hostname" {
   value = random_pet.hostname.id
 }
+
+output "service_name" {
+  value = var.service_name
+}

--- a/test_data/httpd_efs/outputs.tf
+++ b/test_data/httpd_efs/outputs.tf
@@ -5,3 +5,7 @@ output "zone_id" {
 output "jumphost_hostname" {
   value = random_pet.hostname.id
 }
+
+output "service_name" {
+  value = var.service_name
+}

--- a/test_data/httpd_tcp/outputs.tf
+++ b/test_data/httpd_tcp/outputs.tf
@@ -9,3 +9,7 @@ output "jumphost_hostname" {
 output "load_balancer_dns_name" {
   value = module.httpd.load_balancer_dns_name
 }
+
+output "service_name" {
+  value = var.service_name
+}

--- a/tests/test_httpd.py
+++ b/tests/test_httpd.py
@@ -24,6 +24,7 @@ def test_module(
     aws_region,
     test_zone_name,
     aws_provider_version,
+    cleanup_ecs_task_definitions,
 ):
     subnet_public_ids = service_network["subnet_public_ids"]["value"]
     subnet_private_ids = service_network["subnet_private_ids"]["value"]
@@ -62,5 +63,6 @@ def test_module(
         json_output=True,
     ) as tf_httpd_output:
         LOG.info(json.dumps(tf_httpd_output, indent=4))
+        cleanup_ecs_task_definitions(tf_httpd_output["service_name"]["value"])
         for url in [f"https://www.{test_zone_name}", f"https://{test_zone_name}"]:
             wait_for_success(url)

--- a/tests/test_httpd_autoscaling.py
+++ b/tests/test_httpd_autoscaling.py
@@ -34,6 +34,7 @@ def test_module(
     test_role_arn,
     aws_region,
     aws_provider_version,
+    cleanup_ecs_task_definitions,
 ):
     subnet_public_ids = service_network["subnet_public_ids"]["value"]
     subnet_private_ids = service_network["subnet_private_ids"]["value"]
@@ -80,5 +81,6 @@ def test_module(
         json_output=True,
     ) as tf_httpd_output:
         LOG.info(json.dumps(tf_httpd_output, indent=4))
+        cleanup_ecs_task_definitions(tf_httpd_output["service_name"]["value"])
         for url in [f"https://www.{test_zone_name}", f"https://{test_zone_name}"]:
             wait_for_success(url)

--- a/tests/test_httpd_efs.py
+++ b/tests/test_httpd_efs.py
@@ -23,6 +23,7 @@ def test_module(
     test_role_arn,
     aws_region,
     aws_provider_version,
+    cleanup_ecs_task_definitions,
 ):
     subnet_public_ids = service_network["subnet_public_ids"]["value"]
     subnet_private_ids = service_network["subnet_private_ids"]["value"]
@@ -61,3 +62,4 @@ def test_module(
         json_output=True,
     ) as tf_httpd_output:
         LOG.info(json.dumps(tf_httpd_output, indent=4))
+        cleanup_ecs_task_definitions(tf_httpd_output["service_name"]["value"])


### PR DESCRIPTION
  - Upgrade pytest-infrahouse from 0.9.3 to 0.17.1 to get cleanup_ecs_task_definitions fixture
  - Automatically deregister and delete old task definitions after tests complete

This prevents ECS task definition versions from accumulating in AWS after test runs,
similar to the approach used in terraform-aws-sqs-ecs repository.
