### PR TITLE
feat!: migrate default AMI from Amazon Linux 2 to Amazon Linux 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [6.0.0] - TBD
+
+### Changed
+
+- **BREAKING**: Default AMI changed from Amazon Linux 2 to Amazon Linux 2023
+  - AMI filter updated from `amzn2-ami-ecs-hvm-*` to `al2023-ami-ecs-hvm-*`
+  - Existing deployments will gradually replace EC2 instances with AL2023-based instances
+  - Users can continue using Amazon Linux 2 by explicitly setting the `ami_id` variable
+  - See README.md "Migration from Amazon Linux 2 to Amazon Linux 2023" section for details
+
+### Migration Notes
+
+**For existing users upgrading from v5.x:**
+
+This is a breaking change. When you upgrade to v6.0.0, your autoscaling group will eventually replace all EC2 instances with new instances running Amazon Linux 2023 instead of Amazon Linux 2.
+
+**Option 1: Continue using Amazon Linux 2** (recommended for existing production deployments)
+```hcl
+module "ecs" {
+  source  = "infrahouse/ecs/aws"
+  version = "6.0.0"
+  ami_id  = "<your-al2-ami-id>"  # Explicitly set to your AL2 AMI
+  # ... rest of your configuration
+}
+```
+
+**Option 2: Adopt Amazon Linux 2023**
+- Simply upgrade the module version
+- Test thoroughly in non-production environments first
+- Plan for instance replacement during a maintenance window
+- Monitor ECS task migration during instance replacement
+
+### Why Amazon Linux 2023?
+
+- Extended support lifecycle (5 years per major release)
+- Improved security posture with frequent updates
+- Better systemd integration
+- Deterministic package updates
+- Amazon Linux 2 enters maintenance support on June 30, 2024, with end of life on June 30, 2025
+
+For more details on the differences between AL2 and AL2023, see the [AWS documentation](https://docs.aws.amazon.com/linux/al2023/ug/compare-with-al2.html).
+
+## [5.12.0] - Previous Release
+
+### Added
+- Support for AWS provider version 6
+- Cleanup of ECS task definitions to prevent accumulation
+
+---
+
+## Earlier Releases
+
+See Git history for changes prior to v5.12.0.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,44 @@ if you want a popular setup https://domain.com + https://www.domain.com/.
 
 For usage see how the module is used in the using tests in `test_data/test_module`.
 
+## Migration from Amazon Linux 2 to Amazon Linux 2023
+
+**Breaking Change (v6.0.0+):** This module now defaults to Amazon Linux 2023 (AL2023) ECS-optimized AMIs instead of Amazon Linux 2.
+
+### What Changed
+- Default AMI filter changed from `amzn2-ami-ecs-hvm-*` to `al2023-ami-ecs-hvm-*`
+- This affects all new ECS instances launched by the autoscaling group
+
+### Migration Path
+
+**Option 1: Stay on Amazon Linux 2 (Recommended for existing deployments)**
+If you want to continue using Amazon Linux 2, explicitly set the `ami_id` variable:
+```hcl
+module "httpd" {
+  source  = "infrahouse/ecs/aws"
+  version = "6.0.0"
+  ami_id  = "<your-al2-ami-id>"  # Lock to Amazon Linux 2
+  # ... other configuration
+}
+```
+
+**Option 2: Migrate to Amazon Linux 2023**
+To adopt AL2023, simply upgrade the module version. Note that existing instances will need to be replaced:
+1. The autoscaling group will gradually replace instances with AL2023-based ones
+2. During replacement, ECS tasks will be migrated to new instances
+3. Test thoroughly in a non-production environment first
+
+### Key Differences
+- AL2023 uses systemd-based initialization (cloud-init still supported)
+- Different default package versions
+- Improved security posture and longer support lifecycle
+- See [AWS AL2023 documentation](https://docs.aws.amazon.com/linux/al2023/ug/compare-with-al2.html) for detailed differences
+
+### Custom AMIs
+If you use custom AMIs based on Amazon Linux 2, you must:
+- Rebuild your AMIs based on AL2023, OR
+- Explicitly set the `ami_id` variable to your custom AL2 AMI
+
 ```hcl
 module "httpd" {
   source  = "infrahouse/ecs/aws"
@@ -151,7 +189,7 @@ module "httpd" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_log_force_destroy"></a> [access\_log\_force\_destroy](#input\_access\_log\_force\_destroy) | Destroy S3 bucket with access logs even if non-empty | `bool` | `false` | no |
-| <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | Image for host EC2 instances. If not specified, the latest Amazon image will be used. | `string` | `null` | no |
+| <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | Image for host EC2 instances. If not specified, the latest Amazon Linux 2023 ECS-optimized image will be used. | `string` | `null` | no |
 | <a name="input_asg_health_check_grace_period"></a> [asg\_health\_check\_grace\_period](#input\_asg\_health\_check\_grace\_period) | ASG will wait up to this number of seconds for instance to become healthy | `number` | `300` | no |
 | <a name="input_asg_instance_type"></a> [asg\_instance\_type](#input\_asg\_instance\_type) | EC2 instances type | `string` | `"t3.micro"` | no |
 | <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | Maximum number of instances in ASG. By default, it's calculated based on number of tasks and their memory requirements. | `number` | `null` | no |

--- a/datasources.tf
+++ b/datasources.tf
@@ -10,7 +10,7 @@ data "aws_ami" "ecs" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-ecs-hvm-*"]
+    values = ["al2023-ami-ecs-hvm-*"]
   }
 
   filter {

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "access_log_force_destroy" {
 }
 
 variable "ami_id" {
-  description = "Image for host EC2 instances. If not specified, the latest Amazon image will be used."
+  description = "Image for host EC2 instances. If not specified, the latest Amazon Linux 2023 ECS-optimized image will be used."
   type        = string
   default     = null
 }


### PR DESCRIPTION
  ## Summary

  This PR updates the default AMI for ECS host instances from Amazon Linux 2 to Amazon Linux 2023. This is a **breaking change** that will affect all users who don't explicitly set the `ami_id`
  variable.

  ## Changes

  - Updated AMI filter in `datasources.tf` from `amzn2-ami-ecs-hvm-*` to `al2023-ami-ecs-hvm-*`
  - Updated `ami_id` variable description to reflect AL2023 as the default
  - Added comprehensive migration guide in README.md
  - Created CHANGELOG.md documenting the breaking change

  ## Migration Path

  ### Option 1: Stay on Amazon Linux 2 (Recommended for existing deployments)
  Users can continue using Amazon Linux 2 by explicitly setting the `ami_id` variable:
  ```hcl
  module "ecs" {
    source  = "infrahouse/ecs/aws"
    version = "6.0.0"
    ami_id  = "<your-al2-ami-id>"  # Lock to Amazon Linux 2
    # ... rest of configuration
  }

  Option 2: Migrate to Amazon Linux 2023

  Simply upgrade the module version. Note:
  - Autoscaling group will gradually replace instances with AL2023-based ones
  - ECS tasks will be migrated to new instances during replacement
  - Test thoroughly in non-production environments first

  Why This Change?

  - Amazon Linux 2 enters maintenance support on June 30, 2024
  - Amazon Linux 2 reaches end of life on June 30, 2025
  - AL2023 provides extended support lifecycle (5 years per major release)
  - Improved security posture and better systemd integration

  Testing

  - ✅ Existing tests pass with AL2023 AMIs
  - ✅ Documentation updated and reviewed

  Breaking Change Notice

  This will be released as v6.0.0 following semantic versioning. Users upgrading from v5.x should review the migration guide in README.md before upgrading.

  Related Documentation

  - https://docs.aws.amazon.com/linux/al2023/ug/compare-with-al2.html
  - See CHANGELOG.md for detailed migration notes
