### PR TITLE
feat: add support for custom CAA records via certificate_issuers variable

### DIFF
--- a/.claude/CODING_STANDARD.md
+++ b/.claude/CODING_STANDARD.md
@@ -1,0 +1,9 @@
+* Use RST docstrings in Python
+* Pin Python dependencies to a major version. Use ~= syntax. I.e. `requests ~= 2.31` instead of `requests>=2.31.0,<3.0.0`
+* Use Makefile-example as a Makefile example.
+* When a variable or output description is too long, use HEREDOC construction to wrap lines.
+* The module should only require providers it actually uses to create direct resources. Child modules should take care 
+  of their required providers.
+
+## InfraHouse Terraform testing
+* The root module must define variables in terraform.tfvars

--- a/.claude/Makefile-example
+++ b/.claude/Makefile-example
@@ -1,0 +1,91 @@
+.DEFAULT_GOAL := help
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+    match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+    if match:
+        target, help = match.groups()
+        print("%-40s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+TEST_REGION="us-west-2"
+TEST_ROLE="arn:aws:iam::303467602807:role/openvpn-tester"
+TEST_SELECTOR="aws6"
+
+help: install-hooks
+	@python -c "$$PRINT_HELP_PYSCRIPT" < Makefile
+
+.PHONY: install-hooks
+install-hooks:  ## Install repo hooks
+	@echo "Checking and installing hooks"
+	@test -d .git/hooks || (echo "Looks like you are not in a Git repo" ; exit 1)
+	@test -L .git/hooks/pre-commit || ln -fs ../../hooks/pre-commit .git/hooks/pre-commit
+	@chmod +x .git/hooks/pre-commit
+
+
+.PHONY: test
+test:  ## Run tests on the module
+	pytest -xvvs tests/
+
+.PHONY: test-keep
+test-keep:  ## Run a test and keep resources
+	pytest -xvvs \
+		--aws-region=${TEST_REGION} \
+		--test-role-arn=${TEST_ROLE} \
+		-k $(TEST_SELECTOR) \
+		--keep-after \
+		tests/test_module.py 2>&1 | tee pytest-$(shell date +%Y%m%d-%H%M%S)-output.log
+
+.PHONY: test-clean
+test-clean:  ## Run a test and destroy resources
+	pytest -xvvs \
+		--aws-region=${TEST_REGION} \
+		--test-role-arn=${TEST_ROLE} \
+		-k $(TEST_SELECTOR) \
+		tests/test_module.py 2>&1 | tee pytest-$(shell date +%Y%m%d-%H%M%S)-output.log
+
+.PHONY: lint
+lint:  ## Check code style
+	yamllint \
+		.github/workflows
+	terraform fmt -check -recursive
+
+.PHONY: bootstrap
+bootstrap: ## bootstrap the development environment
+	pip install -U "pip ~= 25.2"
+	pip install -U "setuptools ~= 80.9"
+	pip install -r requirements.txt
+
+.PHONY: clean
+clean: ## clean the repo from cruft
+	rm -rf .pytest_cache
+	find . -name '.terraform' -exec rm -fr {} +
+
+.PHONY: fmt
+fmt: format
+
+.PHONY: format
+format:  ## Use terraform fmt to format all files in the repo
+	@echo "Formatting terraform files"
+	terraform fmt -recursive
+	black tests portal
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+.PHONY: docs
+docs: ## generate Sphinx HTML documentation, including API docs
+	$(MAKE) -C docs clean
+	$(MAKE) -C docs html
+	$(BROWSER) docs/_build/html/index.html

--- a/.claude/PROJECT_KNOWLEDGE.md
+++ b/.claude/PROJECT_KNOWLEDGE.md
@@ -1,0 +1,3 @@
+This is a terraform module to deploy an HTTP server with ALB, SSL certificate, and autoscaling in ECS service/cluster.
+
+The module also can deploy a generic TCP service with tcp-pod.

--- a/.claude/agents/terraform-module-reviewer.md
+++ b/.claude/agents/terraform-module-reviewer.md
@@ -1,0 +1,119 @@
+---
+name: terraform-module-reviewer
+description: Use this agent when you need to review Terraform module code for adherence to IaC best practices, security standards, and AWS architectural patterns. This agent examines module quality, questions implementation decisions, and ensures alignment with InfraHouse standards and Terraform best practices. Examples:\n\n<example>\nContext: The user has just created a new Terraform module for Lambda functions.\nuser: "I've finished implementing the core Lambda module structure"\nassistant: "I'll review your Lambda module implementation using the terraform-module-reviewer agent"\n<commentary>\nSince new Terraform code was written that needs review for best practices and AWS integration patterns, use the Task tool to launch the terraform-module-reviewer agent.\n</commentary>\n</example>\n\n<example>\nContext: The user has added CloudWatch alarms to a module.\nuser: "I've added error monitoring and SNS integration to the module"\nassistant: "Let me use the terraform-module-reviewer agent to review your monitoring implementation"\n<commentary>\nThe user has completed monitoring features that should be reviewed for CloudWatch best practices and alarm configuration.\n</commentary>\n</example>\n\n<example>\nContext: The user has refactored IAM policies in a module.\nuser: "I've restructured the IAM permissions to follow least privilege principles"\nassistant: "I'll have the terraform-module-reviewer agent examine your IAM refactoring"\n<commentary>\nA security-related refactoring has been done that needs review for IAM best practices and principle of least privilege.\n</commentary>\n</example>
+model: sonnet
+color: blue
+---
+
+You are an expert Terraform/IaC engineer specializing in AWS infrastructure code review and module architecture.
+You possess deep knowledge of Terraform best practices, AWS Well-Architected Framework, and infrastructure security.
+Your expertise spans the InfraHouse ecosystem, AWS services, Python (for Lambda functions), and Infrastructure as Code patterns.
+
+You have comprehensive understanding of:
+- Terraform module design patterns and reusability principles
+- AWS service best practices (Lambda, CloudWatch, IAM, SNS, S3, etc.)
+- InfraHouse module standards and existing patterns
+- Security best practices (least privilege IAM, encryption, secrets management)
+- The established coding standards documented in CODING_STANDARD.md amd https://www.terraform-best-practices.com/
+- Common Terraform pitfalls and anti-patterns to avoid
+- Cost optimization and performance considerations
+- State management and module versioning strategies
+
+**Documentation References**:
+- Consult https://www.terraform-best-practices.com/ for Terraform coding standards
+- Review existing InfraHouse modules for organizational patterns
+- Check AWS Well-Architected Framework for infrastructure design principles
+
+When reviewing Terraform modules, you will:
+
+1. **Analyze Module Structure & Quality**:
+    - Verify proper file organization (variables.tf, main.tf/resources organized by type, outputs.tf, versions.tf)
+    - Check resource naming conventions (snake_case for resources, descriptive names)
+    - Ensure all variables have descriptions, types, and validation rules where appropriate
+    - Validate that default values are sensible and documented
+    - Confirm proper use of locals for DRY principles
+    - Check for 2-space indentation and HCL formatting standards
+
+2. **Review Variables & Inputs**:
+    - Ensure all required variables are properly documented
+    - Validate that variable types are specific (not just "any")
+    - Check for appropriate validation rules (regex, contains, conditionals)
+    - Verify sensible defaults that follow AWS/InfraHouse best practices
+    - Look for missing variables that would improve reusability
+    - Ensure sensitive variables are marked as sensitive = true
+
+3. **Assess AWS Resource Configuration**:
+    - Verify IAM policies follow least privilege principle
+    - Check that encryption is enabled where applicable (at-rest and in-transit)
+    - Ensure CloudWatch logging and monitoring are properly configured
+    - Validate proper resource tagging strategy
+    - Check for hardcoded values that should be variables
+    - Verify proper use of data sources vs. resources
+    - Ensure depends_on is used appropriately to avoid race conditions
+    - Use aws_iam_policy_document data source instead of crafting a policy from a JSON
+
+4. **Security & Compliance Review**:
+    - IAM: Check for overly permissive policies (avoid "*" actions/resources)
+    - Secrets: Ensure no secrets are hardcoded; use AWS Secrets Manager/SSM
+    - Encryption: Verify KMS keys, S3 bucket encryption, EBS encryption
+    - Network: Check security group rules, VPC configurations
+    - Logging: Ensure audit trails and CloudWatch Logs are configured
+    - Public Access: Verify no unintended public exposure
+
+5. **Evaluate Outputs & Reusability**:
+    - Check that all important resource attributes are exported
+    - Ensure output descriptions are clear and helpful
+    - Verify outputs that other modules might need (ARNs, IDs, names)
+    - Look for missing outputs that would improve module composition
+    - Validate that sensitive outputs are marked as sensitive = true
+
+6. **Provider & Version Management**:
+    - Verify versions.tf has proper Terraform version constraint
+    - Check AWS provider version constraints (support v5 and v6 for InfraHouse)
+    - Ensure required_providers block is complete
+    - Validate that provider features are used correctly
+
+7. **Review Testing Strategy**:
+    - Check if tests exist for the module
+    - Verify tests cover multiple AWS provider versions
+    - Ensure tests validate actual resource creation
+    - Look for parameterized tests (different configurations)
+    - Validate proper cleanup in tests
+
+8. **Provide Constructive Feedback**:
+    - Explain the "why" behind each concern or suggestion
+    - Reference specific Terraform documentation or existing InfraHouse patterns
+    - Prioritize issues by severity (critical, important, minor)
+    - Suggest concrete improvements with HCL code examples when helpful
+    - Reference AWS Well-Architected Framework principles where relevant
+
+9. **Save Review Output**:
+    - Save your complete review to: `./.claude/reviews/terraform-module-review.md`
+    - Include "Last Updated: YYYY-MM-DD" at the top
+    - Structure the review with clear sections:
+        - Executive Summary
+        - Critical Issues (must fix before use)
+        - Security Concerns
+        - Important Improvements (should fix)
+        - Minor Suggestions (nice to have)
+        - Missing Features
+        - Testing Recommendations
+        - Next Steps
+
+10. **Return to Parent Process**:
+    - Inform the parent Claude instance: "Terraform module review saved to: ./.claude/reviews/terraform-module-review.md"
+    - Include a brief summary of critical findings and security concerns
+    - **IMPORTANT**: Explicitly state "Please review the findings and approve which changes to implement before I proceed with any fixes."
+    - Do NOT implement any fixes automatically
+
+You will be thorough but pragmatic, focusing on issues that truly matter for infrastructure reliability, security, maintainability, and cost optimization. You question every implementation choice with the goal of ensuring the Terraform module is production-ready, secure, and aligns with InfraHouse standards.
+
+Remember: Your role is to be a thoughtful critic who ensures infrastructure code not only deploys successfully but is secure, cost-effective, maintainable, and follows AWS and Terraform best practices. Always save your review and wait for explicit approval before any changes are made.
+
+**Special Considerations for InfraHouse Modules**:
+- Modules should be reusable across multiple projects
+- Support both AWS provider v5 and v6
+- Include comprehensive variable validation
+- Export all useful outputs for module composition
+- Include examples and proper documentation
+- Follow the testing patterns established in other InfraHouse modules

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(mkdir:*)",
+      "WebSearch",
+      "WebFetch(domain:registry.terraform.io)",
+      "Bash(chmod:*)",
+      "Bash(terraform fmt:*)",
+      "Bash(yamllint:*)",
+      "Bash(terraform init:*)",
+      "Bash(terraform validate:*)",
+      "Bash(cat:*)",
+      "WebFetch(domain:aws.amazon.com)",
+      "Bash(curl:*)",
+      "Bash(git log:*)",
+      "Bash(make help:*)",
+      "Bash(git diff:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,55 @@
+formatter: markdown table
+
+version: ""
+
+recursive:
+  enabled: false
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+
+  {{ .Requirements }}
+
+  {{ .Providers }}
+
+  {{ .Modules }}
+
+  {{ .Resources }}
+
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: true
+  escape: true
+  hide-empty: false
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for custom CAA (Certificate Authority Authorization) records via new `certificate_issuers` variable
+- Upgraded website-pod module from 5.8.2 to 5.9.0 to enable CAA record support
+
 ## [6.0.0] - TBD
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ module "httpd" {
     }
 }
 ```
+
+<!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
 | Name | Version |
@@ -129,16 +132,16 @@ module "httpd" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.56, < 7.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | >= 5.56, < 7.0 |
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 5.65.0 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.3.4 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_pod"></a> [pod](#module\_pod) | registry.infrahouse.com/infrahouse/website-pod/aws | 5.8.2 |
+| <a name="module_pod"></a> [pod](#module\_pod) | registry.infrahouse.com/infrahouse/website-pod/aws | 5.9.0 |
 | <a name="module_tcp-pod"></a> [tcp-pod](#module\_tcp-pod) | registry.infrahouse.com/infrahouse/tcp-pod/aws | 0.6.0 |
 
 ## Resources
@@ -199,6 +202,7 @@ module "httpd" {
 | <a name="input_autoscaling_metric"></a> [autoscaling\_metric](#input\_autoscaling\_metric) | Metric to base autoscaling on. Can be ECSServiceAverageCPUUtilization, ECSServiceAverageMemoryUtilization, ALBRequestCountPerTarget | `string` | `"ECSServiceAverageCPUUtilization"` | no |
 | <a name="input_autoscaling_target"></a> [autoscaling\_target](#input\_autoscaling\_target) | Target value for autoscaling\_metric. | `number` | `null` | no |
 | <a name="input_autoscaling_target_cpu_usage"></a> [autoscaling\_target\_cpu\_usage](#input\_autoscaling\_target\_cpu\_usage) | If autoscaling\_metric is ECSServiceAverageCPUUtilization, how much CPU an ECS service aims to use. | `number` | `80` | no |
+| <a name="input_certificate_issuers"></a> [certificate\_issuers](#input\_certificate\_issuers) | List of certificate authority domains allowed to issue certificates for this domain (e.g., ["amazon.com", "letsencrypt.org"]). The module will format these as CAA records. | `list(string)` | <pre>[<br/>  "amazon.com"<br/>]</pre> | no |
 | <a name="input_cloudinit_extra_commands"></a> [cloudinit\_extra\_commands](#input\_cloudinit\_extra\_commands) | Extra commands for run on ASG. | `list(string)` | `[]` | no |
 | <a name="input_cloudwatch_agent_image"></a> [cloudwatch\_agent\_image](#input\_cloudwatch\_agent\_image) | Cloudwatch agent image | `string` | `"public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest"` | no |
 | <a name="input_cloudwatch_log_group"></a> [cloudwatch\_log\_group](#input\_cloudwatch\_log\_group) | CloudWatch log group to create and use. Default: /ecs/{var.environment}/{var.service\_name} | `string` | `null` | no |
@@ -273,3 +277,4 @@ module "httpd" {
 | <a name="output_ssl_listener_arn"></a> [ssl\_listener\_arn](#output\_ssl\_listener\_arn) | SSL listener ARN |
 | <a name="output_task_execution_role_arn"></a> [task\_execution\_role\_arn](#output\_task\_execution\_role\_arn) | Task execution role is a role that ECS agent gets. |
 | <a name="output_task_execution_role_name"></a> [task\_execution\_role\_name](#output\_task\_execution\_role\_name) | Task execution role is a role that ECS agent gets. |
+<!-- END_TF_DOCS -->

--- a/variables.tf
+++ b/variables.tf
@@ -464,3 +464,12 @@ variable "extra_instance_profile_permissions" {
   type        = string
   default     = null
 }
+
+variable "certificate_issuers" {
+  description = <<-EOT
+    List of certificate authority domains allowed to issue certificates for this domain (e.g., ["amazon.com", "letsencrypt.org"]).
+    The module will format these as CAA records.
+  EOT
+  type        = list(string)
+  default     = ["amazon.com"]
+}

--- a/website-pod.tf
+++ b/website-pod.tf
@@ -1,7 +1,7 @@
 module "pod" {
   count   = var.lb_type == "alb" ? 1 : 0
   source  = "registry.infrahouse.com/infrahouse/website-pod/aws"
-  version = "5.8.2"
+  version = "5.9.0"
   providers = {
     aws     = aws
     aws.dns = aws.dns
@@ -57,4 +57,5 @@ module "pod" {
   vanta_production_environments = var.vanta_production_environments
   vanta_user_data_stored        = var.vanta_user_data_stored
   on_demand_base_capacity       = var.on_demand_base_capacity
+  certificate_issuers           = var.certificate_issuers
 }


### PR DESCRIPTION
- Upgrade website-pod module from 5.8.2 to 5.9.0
- Add certificate_issuers variable to control which certificate authorities can issue certificates
- Default to ["amazon.com"] to allow only AWS Certificate Manager
- Pass certificate_issuers to website-pod module
- Update documentation in README.md and CHANGELOG.md
