### PR TITLE
feat: add Route53 weighted routing for zero-downtime migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## First Steps
+
+**Your first tool call in this repository MUST be reading .claude/CODING_STANDARD.md.
+Do not read any other files, search, or take any actions until you have read it.**
+This contains InfraHouse's comprehensive coding standards for Terraform, Python, and general formatting rules.
+
+## Module Overview
+
+This is `terraform-aws-ecs`, an InfraHouse Terraform module that creates an AWS ECS cluster with EC2 capacity provider to run Docker containers. It provisions:
+- ECS Cluster with managed Auto Scaling Group
+- Application Load Balancer (ALB) or Network Load Balancer (NLB)
+- SSL certificates with automatic DNS validation
+- Task-level autoscaling
+- CloudWatch logging and alarms
+- Optional EFS volume support
+
+## Architecture
+
+The module uses two sub-modules based on `lb_type`:
+- `module.pod` (website-pod) - Used for ALB (`lb_type = "alb"`)
+- `module.tcp-pod` - Used for NLB (`lb_type = "nlb"`)
+
+Key files:
+- `main.tf` - ECS cluster, capacity provider, task definition, and service
+- `website-pod.tf` / `tcp-pod.tf` - Load balancer configuration via sub-modules
+- `autoscaling.tf` - Task-level autoscaling policies
+- `iam.tf` - Task execution role and instance roles
+- `cloudwatch.tf` - Log groups for ECS tasks
+- `cloudwatch_agent.tf` - Sidecar CloudWatch agent for EC2 metrics
+- `locals.tf` - Computed values and ASG sizing calculations
+
+## Development Commands
+
+```bash
+# Setup development environment
+make bootstrap
+
+# Format code (Terraform + Python)
+make format
+
+# Lint code
+make lint
+
+# Validate Terraform
+make validate
+
+# Run tests (keeps infrastructure for debugging)
+make test-keep
+
+# Run tests with cleanup (before PR)
+make test-clean
+
+# Run specific test with filter
+TEST_PATH=tests/test_httpd.py TEST_FILTER="test_ and aws-6" make test-keep
+```
+
+## Testing
+
+Tests use pytest with pytest-infrahouse fixtures and create real AWS infrastructure:
+- Test configurations are in `test_data/` (httpd, httpd_autoscaling, httpd_efs, httpd_tcp)
+- Tests run against two AWS provider versions: `~> 5.56` and `~> 6.0`
+- `conftest.py` contains helper functions like `wait_for_success()` for health checks
+
+To run a single test:
+```bash
+pytest -xvvs tests/test_httpd.py -k "test_module and aws-6"
+```
+
+## Key Variables
+
+Required:
+- `service_name`, `docker_image`, `container_port`
+- `asg_subnets`, `load_balancer_subnets`
+- `zone_id`, `dns_names`
+- `alarm_emails`
+
+The module auto-calculates `asg_max_size` based on `task_max_count` and container resource requirements (see `locals.tf:80-92`).
+
+## Providers
+
+Requires two AWS provider aliases:
+```hcl
+providers = {
+  aws     = aws      # Main provider
+  aws.dns = aws      # For DNS/Route53 (can be same or different account)
+}
+```
+
+## Version Management
+
+- Current version tracked in `locals.tf` as `local.module_version`
+- Version bumping: `make release-patch`, `make release-minor`, `make release-major`
+- CHANGELOG auto-generated with git-cliff

--- a/tcp-pod.tf
+++ b/tcp-pod.tf
@@ -1,3 +1,7 @@
+# Note: Weighted routing (dns_routing_policy, dns_weight, dns_set_identifier)
+# is not yet supported by the tcp-pod module. See validation check
+# "weighted_routing_alb_only" in validations.tf for enforcement.
+# Tracking issue: https://github.com/infrahouse/terraform-aws-tcp-pod/issues/30
 module "tcp-pod" {
   count   = var.lb_type == "nlb" ? 1 : 0
   source  = "registry.infrahouse.com/infrahouse/tcp-pod/aws"

--- a/validations.tf
+++ b/validations.tf
@@ -222,6 +222,75 @@ check "memory_reservation_within_limit" {
   }
 }
 
+# Validate weighted routing configuration
+check "weighted_routing_requires_set_identifier" {
+  assert {
+    condition     = var.dns_routing_policy == "simple" ? true : var.dns_set_identifier != null
+    error_message = <<-EOF
+      ╔════════════════════════════════════════════════════════════════════════╗
+      ║                  ⚠️  CONFIGURATION ERROR ⚠️                            ║
+      ╚════════════════════════════════════════════════════════════════════════╝
+
+      When using dns_routing_policy = "weighted", you must also set dns_set_identifier.
+
+      Current configuration:
+        - dns_routing_policy: ${var.dns_routing_policy}
+        - dns_set_identifier: ${var.dns_set_identifier == null ? "null (not set)" : var.dns_set_identifier}
+
+      Problem:
+        Route53 weighted routing records require a unique set_identifier to distinguish
+        between multiple records with the same name.
+
+      Solution:
+        Add a unique dns_set_identifier to your configuration:
+
+        dns_routing_policy = "weighted"
+        dns_set_identifier = "my-service-v1"  # Must be unique per DNS record name
+        dns_weight         = 100
+
+      Naming conventions for dns_set_identifier:
+        - "production-blue", "production-green" (blue/green deployments)
+        - "v1", "v2", "v3" (version-based)
+        - "website-pod", "ecs-service" (module-based)
+
+      ════════════════════════════════════════════════════════════════════════
+    EOF
+  }
+}
+
+# Validate weighted routing is only supported for ALB
+check "weighted_routing_alb_only" {
+  assert {
+    condition     = var.dns_routing_policy == "simple" ? true : var.lb_type == "alb"
+    error_message = <<-EOF
+      ╔════════════════════════════════════════════════════════════════════════╗
+      ║                  ⚠️  CONFIGURATION ERROR ⚠️                            ║
+      ╚════════════════════════════════════════════════════════════════════════╝
+
+      Weighted routing is currently only supported for ALB (lb_type = "alb").
+
+      Current configuration:
+        - lb_type:            ${var.lb_type}
+        - dns_routing_policy: ${var.dns_routing_policy}
+        - dns_set_identifier: ${var.dns_set_identifier == null ? "null (not set)" : var.dns_set_identifier}
+
+      Problem:
+        The tcp-pod module (used for NLB) does not yet support weighted routing.
+        This feature is only available when using an Application Load Balancer.
+
+      Solution:
+        Either:
+        1. Use ALB instead of NLB:
+           lb_type = "alb"
+
+        2. Or use simple routing for NLB:
+           dns_routing_policy = "simple"
+
+      ════════════════════════════════════════════════════════════════════════
+    EOF
+  }
+}
+
 # Cross-variable validation: autoscaling_target must be appropriate for the metric type
 locals {
   is_percentage_metric = contains([

--- a/website-pod.tf
+++ b/website-pod.tf
@@ -1,7 +1,7 @@
 module "pod" {
   count   = var.lb_type == "alb" ? 1 : 0
   source  = "registry.infrahouse.com/infrahouse/website-pod/aws"
-  version = "5.14.0"
+  version = "5.17.0"
   providers = {
     aws     = aws
     aws.dns = aws.dns
@@ -19,6 +19,7 @@ module "pod" {
   alb_healthcheck_response_code_matcher = var.healthcheck_response_code_matcher
   alb_healthcheck_interval              = var.healthcheck_interval
   load_balancing_algorithm_type         = var.load_balancing_algorithm_type
+  target_group_protocol                 = var.target_group_protocol
   health_check_grace_period             = var.asg_health_check_grace_period
   health_check_type                     = "EC2"
   attach_target_group_to_asg            = false
@@ -60,4 +61,9 @@ module "pod" {
   on_demand_base_capacity       = var.on_demand_base_capacity
   certificate_issuers           = var.certificate_issuers
   alarm_emails                  = var.alarm_emails
+
+  # Route53 weighted routing for zero-downtime migrations
+  dns_routing_policy = var.dns_routing_policy
+  dns_weight         = var.dns_weight
+  dns_set_identifier = var.dns_set_identifier
 }


### PR DESCRIPTION
  ## Summary

  - Add Route53 weighted routing support for ALB deployments enabling blue/green deployments and gradual traffic migration
  - Add HTTPS target group protocol option for end-to-end encryption
  - Improve documentation and fix minor issues

  ## Changes

  ### New Features
  - **Weighted routing variables**: `dns_routing_policy`, `dns_weight`, `dns_set_identifier` for traffic distribution control
  - **Target group protocol**: `target_group_protocol` variable to support HTTPS backend communication

  ### Validation
  - Cross-variable validation ensuring `dns_set_identifier` is set when using weighted routing
  - Validation preventing weighted routing with NLB (not yet supported)

  ### Documentation
  - Updated README examples to use `registry.infrahouse.com`
  - Fixed resource naming to use snake_case (`my_volume` instead of `my-volume`)
  - Added Examples, Contributing, and License sections
  - Fixed typo in tags description ("creatded" -> "created")
  - Added CLAUDE.md with module overview and development guidance

  ### Dependencies
  - Bump website-pod module from 5.14.0 to 5.17.0

  ## Test plan

  - [ ] Run `make format` and `make lint`
  - [ ] Run `make test-clean` to verify all tests pass
  - [ ] Manually verify weighted routing with two module instances sharing DNS name


