### PR TITLE
Add protocol_version to extra_target_groups

### DIFF
--- a/extra_target_groups.tf
+++ b/extra_target_groups.tf
@@ -1,11 +1,12 @@
 resource "aws_lb_target_group" "extra" {
   for_each = var.lb_type == "alb" ? var.extra_target_groups : {}
 
-  name_prefix = substr("${var.service_name}-", 0, 6)
-  port        = each.value.container_port
-  protocol    = each.value.protocol
-  target_type = "instance"
-  vpc_id      = data.aws_subnet.load_balancer.vpc_id
+  name_prefix      = substr("${var.service_name}-", 0, 6)
+  port             = each.value.container_port
+  protocol         = each.value.protocol
+  protocol_version = each.value.protocol_version
+  target_type      = "instance"
+  vpc_id           = data.aws_subnet.load_balancer.vpc_id
 
   health_check {
     path                = each.value.health_check.path


### PR DESCRIPTION
## Summary
Add `protocol_version` field to `extra_target_groups` variable. Maps to `aws_lb_target_group.protocol_version`. Values: `HTTP1` (default), `HTTP2`, `GRPC`.

## Problem
We tried using `extra_target_groups` to expose a gRPC port (Tempo OTLP on 4317). Health checks fail because the target group defaults to `ProtocolVersion: HTTP1`, but gRPC only speaks HTTP/2. ALB sends HTTP/1.1 probes → gRPC returns no valid HTTP response → targets stuck unhealthy.

Verified locally:
- `curl --http2-prior-knowledge http://localhost:4317/` → HTTP 415 (works over HTTP/2)
- `curl http://localhost:4317/` → `HTTP/0.9 when not allowed` (fails over HTTP/1.1)

## Changes
- `variables.tf`: add `protocol_version = optional(string, "HTTP1")` to the object type + validation
- `extra_target_groups.tf`: pass `protocol_version` to `aws_lb_target_group`

## Usage
```hcl
extra_target_groups = {
  otlp = {
    listener_port    = 4317
    container_port   = 4317
    protocol_version = "GRPC"
    health_check = {
      path    = "/grpc.health.v1.Health/Check"
      matcher = "0"
    }
  }
}
```

## Backwards compatible
Default is `HTTP1` — existing callers are unaffected.

Related: INF-1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)