### PR TITLE
Exclude infra sidecars from Vector Agent default config

### DIFF
--- a/assets/vector_agent_config.yaml.tftmpl
+++ b/assets/vector_agent_config.yaml.tftmpl
@@ -6,7 +6,9 @@ sources:
   docker_logs:
     type: docker_logs
     exclude_containers:
-      - "vector-agent"
+%{ for name in exclude_containers ~}
+      - "${name}"
+%{ endfor ~}
     docker_host: "unix:///var/run/docker.sock"
     auto_partial_merge: true
 

--- a/datasources.tf
+++ b/datasources.tf
@@ -103,6 +103,7 @@ data "cloudinit_config" "ecs" {
                         environment                = var.environment
                         aws_region                 = data.aws_region.current.name
                         vector_aggregator_endpoint = var.vector_aggregator_endpoint
+                        exclude_containers         = concat(["vector-agent"], var.vector_agent_exclude_containers)
                       }
                     )
                   }

--- a/variables.tf
+++ b/variables.tf
@@ -282,6 +282,17 @@ variable "vector_aggregator_endpoint" {
   default     = null
 }
 
+variable "vector_agent_exclude_containers" {
+  description = <<-EOT
+    Container names to exclude from Vector Agent log collection.
+    Only used by the default config template. Ignored if vector_agent_config is set.
+
+    The agent always excludes itself ("vector-agent") regardless of this list.
+  EOT
+  type        = list(string)
+  default     = ["ecs-agent"]
+}
+
 variable "vector_agent_config" {
   description = <<-EOT
     Custom Vector Agent config (YAML string). When provided, replaces


### PR DESCRIPTION
## Summary

The default Vector Agent config only excludes `vector-agent` from log collection. This means infrastructure containers like `ecs-agent` get collected and forwarded to the aggregator — adding noise to the application log pipeline.

This PR makes the exclusion list configurable and excludes `ecs-agent` by default.

## Changes

- New variable `vector_agent_exclude_containers` (`list(string)`, default: `["ecs-agent"]`)
- `vector-agent` is always excluded (hardcoded via `concat`, not user-removable)
- Template renders the list dynamically via `%{ for }` loop
- Ignored when `vector_agent_config` is set (full custom override)

## Usage

```hcl
module "my_service" {
  # Default: only ecs-agent excluded (plus vector-agent always)
  enable_vector_agent            = true
  vector_aggregator_endpoint     = "vector-aggregator.sandbox.tinyfish.io:6000"

  # Optional: exclude additional sidecars
  vector_agent_exclude_containers = ["ecs-agent", "nginx-sidecar", "envoy"]
}
```