### PR TITLE
fix: remove ecs-agent from default vector_agent_exclude_containers

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -312,13 +312,17 @@ variable "vector_agent_task_policy_arns" {
 
 variable "vector_agent_exclude_containers" {
   description = <<-EOT
-    Container names to exclude from Vector Agent log collection.
+    Container name substrings to exclude from Vector Agent log collection.
     Only used by the default config template. Ignored if vector_agent_config is set.
+
+    WARNING: Vector's docker_logs source uses substring matching on container
+    names. For example, "ecs-agent" will also exclude any container whose name
+    contains that substring (e.g. "ecs-agentql-*"). Use specific patterns.
 
     The agent always excludes itself ("vector-agent") regardless of this list.
   EOT
   type        = list(string)
-  default     = ["ecs-agent"]
+  default     = []
 }
 
 variable "ecs_log_level" {


### PR DESCRIPTION
## Summary
- Remove `"ecs-agent"` from default `vector_agent_exclude_containers`
- Add warning about substring matching behavior in variable description

## Problem
Vector's `docker_logs` source uses **prefix matching** on container names for `exclude_containers`. The default value `["ecs-agent"]` unintentionally matches any container whose name starts with `"ecs-agent"` — including application containers like `ecs-agentql-97-agentql-*`.

This caused a production incident where all agentql logs silently stopped flowing to VictoriaLogs after an ASG instance replacement. The Vector agent was healthy and running but its `docker_logs` source reported zero received events because the agentql container was excluded by the substring match.

## Root Cause
```
exclude_containers: ["ecs-agent"]

Container: "ecs-agent"           → excluded (intended)
Container: "ecs-agentql-97-..."  → excluded (unintended — substring match)
```

## Fix
Changed default to `[]` (empty list). Users who need to exclude the ECS agent can explicitly pass `["ecs-agent"]` with awareness of the substring matching behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)