### PR TITLE
fix: bump ecr_image_tagger Lambda memory to 256 MB

### DIFF
--- a/ecr_image_tagger.tf
+++ b/ecr_image_tagger.tf
@@ -7,6 +7,7 @@ module "ecr_image_tagger" {
   description       = "Tags deployed ECR images for lifecycle retention"
   handler           = "main.lambda_handler"
   lambda_source_dir = "${path.module}/assets/ecr_image_tagger"
+  memory_size       = 256
   timeout           = 120
 
   environment_variables = {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
- The ecr_image_tagger Lambda was failing with `Runtime.OutOfMemory` at 128 MB
- Root cause is boto3/botocore import overhead (~80-100 MB), leaving no headroom for execution
- The Lambda code itself is lean — just a few ECS/ECR API calls — no algorithmic fix needed

## Test plan
- [ ] Deploy and trigger a SERVICE_STEADY_STATE event
- [ ] Confirm Lambda completes without OOM errors
- [ ] Check CloudWatch metrics for actual memory usage at 256 MB
