### PR TITLE
feat: pass memory_size to pass to ecr image tagger

### DIFF
--- a/ecr_image_tagger.tf
+++ b/ecr_image_tagger.tf
@@ -8,6 +8,7 @@ module "ecr_image_tagger" {
   handler           = "main.lambda_handler"
   lambda_source_dir = "${path.module}/assets/ecr_image_tagger"
   timeout           = 120
+  memory_size       = var.ecr_image_tagger_memory_size
 
   environment_variables = {
     ECS_CLUSTER_NAME    = aws_ecs_cluster.ecs.name

--- a/variables.tf
+++ b/variables.tf
@@ -998,6 +998,12 @@ variable "ecr_image_tagger_log_level" {
   }
 }
 
+variable "ecr_image_tagger_memory_size" {
+  description = "Memory size in MB for the ECR image tagger Lambda function."
+  type        = number
+  default     = 128
+}
+
 variable "deployed_image_tag_prefix" {
   description = <<-EOT
     Prefix for the tag applied to ECR images after successful


### PR DESCRIPTION
In some cases, ECR image tagger uses more memory than default value