### PR TITLE
feat: add gpu_count variable for ECS GPU task support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,14 @@ resource "aws_ecs_task_definition" "ecs" {
             "interval" : 30,
             "startPeriod" : null
           }
+        } : {},
+        var.gpu_count > 0 ? {
+          resourceRequirements = [
+            {
+              type  = "GPU"
+              value = tostring(var.gpu_count)
+            }
+          ]
         } : {}
       )
     ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "service_arn" {
   )
 }
 
+output "task_definition_arn" {
+  description = "ARN of the ECS task definition."
+  value       = aws_ecs_task_definition.ecs.arn
+}
+
 output "asg_arn" {
   description = "Autoscaling group ARN created for the ECS service."
   value       = local.arg_arn

--- a/test_data/test_gpu/datasources.tf
+++ b/test_data/test_gpu/datasources.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "this" {}
+data "aws_region" "current" {}
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/test_data/test_gpu/main.tf
+++ b/test_data/test_gpu/main.tf
@@ -1,0 +1,28 @@
+module "httpd" {
+  source = "../../"
+  providers = {
+    aws     = aws
+    aws.dns = aws
+  }
+  load_balancer_subnets         = var.subnet_public_ids
+  asg_subnets                   = var.subnet_private_ids
+  dns_names                     = [""]
+  docker_image                  = "httpd"
+  container_port                = 80
+  service_name                  = var.service_name
+  zone_id                       = var.zone_id
+  container_healthcheck_command = "ls"
+  container_command = [
+    "sh", "-c",
+    "echo '<html><body><h1>It works!</h1></body></html>' > /usr/local/apache2/htdocs/index.html && httpd-foreground"
+  ]
+  enable_cloudwatch_logs   = true
+  access_log_force_destroy = true
+  alarm_emails             = ["test@example.com"]
+  gpu_count                = var.gpu_count
+  replication_region       = local.replication_region
+}
+
+locals {
+  replication_region = var.region == "us-east-1" ? "us-west-2" : "us-east-1"
+}

--- a/test_data/test_gpu/outputs.tf
+++ b/test_data/test_gpu/outputs.tf
@@ -1,0 +1,7 @@
+output "service_name" {
+  value = var.service_name
+}
+
+output "task_definition_arn" {
+  value = module.httpd.task_definition_arn
+}

--- a/test_data/test_gpu/providers.tf
+++ b/test_data/test_gpu/providers.tf
@@ -1,0 +1,15 @@
+provider "aws" {
+  region = var.region
+  dynamic "assume_role" {
+    for_each = var.role_arn != null ? [1] : []
+    content {
+      role_arn = var.role_arn
+    }
+  }
+  default_tags {
+    tags = {
+      "created_by" : "infrahouse/terraform-aws-ecs" # GitHub repository that created a resource
+    }
+
+  }
+}

--- a/test_data/test_gpu/variables.tf
+++ b/test_data/test_gpu/variables.tf
@@ -1,0 +1,30 @@
+variable "environment" {
+  type    = string
+  default = "development"
+}
+variable "region" {
+  type = string
+}
+variable "role_arn" {
+  type    = string
+  default = null
+}
+variable "service_name" {
+  type    = string
+  default = "test-terraform-aws-ecs-gpu"
+}
+variable "zone_id" {
+  type = string
+}
+
+variable "subnet_public_ids" {
+  type = list(string)
+}
+variable "subnet_private_ids" {
+  type = list(string)
+}
+
+variable "gpu_count" {
+  type    = number
+  default = 0
+}

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,115 @@
+import json
+from os import path as osp
+from textwrap import dedent
+from typing import Any
+
+import pytest
+from boto3 import Session
+from pytest_infrahouse import terraform_apply
+
+from tests.conftest import (
+    LOG,
+    TERRAFORM_ROOT_DIR,
+    update_terraform_tf,
+    cleanup_dot_terraform,
+)
+
+
+@pytest.mark.parametrize(
+    "gpu_count, expect_gpu",
+    [
+        (0, False),
+        (1, True),
+        (2, True),
+    ],
+    ids=["no-gpu", "one-gpu", "two-gpu"],
+)
+@pytest.mark.parametrize("aws_provider_version", ["~> 6.0"], ids=["aws-6"])
+def test_gpu_resource_requirements(
+    service_network: dict,
+    keep_after: bool,
+    test_role_arn: str,
+    aws_region: str,
+    subzone: dict,
+    aws_provider_version: str,
+    cleanup_ecs_task_definitions: Any,
+    boto3_session: Session,
+    gpu_count: int,
+    expect_gpu: bool,
+) -> None:
+    """
+    Validate that the task definition includes GPU resourceRequirements
+    when gpu_count > 0 and omits them when gpu_count == 0.
+
+    :param service_network: Fixture providing VPC subnet IDs.
+    :param keep_after: If True, do not destroy infrastructure after test.
+    :param test_role_arn: IAM role ARN to assume for the test.
+    :param aws_region: AWS region for the test.
+    :param subzone: Fixture providing Route53 subzone ID.
+    :param aws_provider_version: AWS provider version constraint.
+    :param cleanup_ecs_task_definitions: Fixture to deregister task definitions.
+    :param boto3_session: Boto3 session for AWS API calls.
+    :param gpu_count: Number of GPUs to request (parametrized).
+    :param expect_gpu: Whether GPU resourceRequirements should be present.
+    """
+    subnet_public_ids = service_network["subnet_public_ids"]["value"]
+    subnet_private_ids = service_network["subnet_private_ids"]["value"]
+    zone_id = subzone["subzone_id"]["value"]
+
+    terraform_module_dir = osp.join(TERRAFORM_ROOT_DIR, "test_gpu")
+    cleanup_dot_terraform(terraform_module_dir)
+    update_terraform_tf(terraform_module_dir, aws_provider_version)
+    with open(osp.join(terraform_module_dir, "terraform.tfvars"), "w") as fp:
+        fp.write(
+            dedent(
+                f"""
+                zone_id       = "{zone_id}"
+                region        = "{aws_region}"
+                gpu_count     = {gpu_count}
+
+                subnet_public_ids   = {json.dumps(subnet_public_ids)}
+                subnet_private_ids  = {json.dumps(subnet_private_ids)}
+                """
+            )
+        )
+        if test_role_arn:
+            fp.write(
+                dedent(
+                    f"""
+                    role_arn      = "{test_role_arn}"
+                    """
+                )
+            )
+
+    with terraform_apply(
+        terraform_module_dir,
+        destroy_after=not keep_after,
+        json_output=True,
+    ) as tf_output:
+        LOG.info(json.dumps(tf_output, indent=4))
+        cleanup_ecs_task_definitions(tf_output["service_name"]["value"])
+
+        task_def_arn = tf_output["task_definition_arn"]["value"]
+        LOG.info("Task definition ARN: %s", task_def_arn)
+
+        ecs_client = boto3_session.client("ecs", region_name=aws_region)
+        response = ecs_client.describe_task_definition(taskDefinition=task_def_arn)
+        container_def = response["taskDefinition"]["containerDefinitions"][0]
+
+        resource_requirements = container_def.get("resourceRequirements", [])
+
+        if expect_gpu:
+            gpu_reqs = [r for r in resource_requirements if r["type"] == "GPU"]
+            assert len(gpu_reqs) == 1, (
+                f"Expected exactly one GPU resourceRequirement, got: {gpu_reqs}"
+            )
+            assert gpu_reqs[0]["value"] == str(gpu_count), (
+                f"Expected GPU value '{gpu_count}', got: '{gpu_reqs[0]['value']}'"
+            )
+            LOG.info("GPU resourceRequirements correctly present: %s", gpu_reqs)
+        else:
+            gpu_reqs = [r for r in resource_requirements if r["type"] == "GPU"]
+            assert len(gpu_reqs) == 0, (
+                f"Expected no GPU resourceRequirements, got: {gpu_reqs}"
+            )
+            LOG.info("GPU resourceRequirements correctly absent")

--- a/variables.tf
+++ b/variables.tf
@@ -407,6 +407,23 @@ variable "container_command" {
   default     = null
 }
 
+variable "gpu_count" {
+  description = <<-EOT
+    Number of GPUs to reserve for the container.
+    When greater than 0, a resourceRequirements block with type "GPU"
+    is added to the container definition.
+
+    Requires ECS instances with GPU capacity (e.g., g4dn, g6e, p3).
+  EOT
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.gpu_count >= 0 && floor(var.gpu_count) == var.gpu_count
+    error_message = "gpu_count must be a non-negative integer. Got: ${var.gpu_count}"
+  }
+}
+
 variable "container_healthcheck_command" {
   description = <<-EOT
     A shell command that a container runs to check if it's healthy.


### PR DESCRIPTION
## Summary
- Adds optional `gpu_count` variable (default `0`) that injects GPU `resourceRequirements` into the ECS container definition
- ECS tasks on GPU instances (g4dn, p3, g6e) need this to access the GPU device
- Backwards compatible: default `0` produces zero diff for existing callers

## Changes
- **variables.tf** — New `gpu_count` variable (type `number`, default `0`, non-negative integer validation)
- **main.tf** — Conditional merge block: `gpu_count > 0` adds `resourceRequirements = [{type = "GPU", value = "<count>"}]`
- **outputs.tf** — New `task_definition_arn` output (useful for programmatic task definition inspection)
- **test_data/test_gpu/** — Minimal Terraform root exercising the module with `gpu_count`
- **tests/test_gpu.py** — Parametrized pytest (`gpu_count=0`, `1`, `2`) asserting on `boto3.describe_task_definition`

## Test plan
- [ ] `make test-clean` — all existing tests stay green (no behavioral change when `gpu_count=0`)
- [ ] New `test_gpu_resource_requirements` validates GPU `resourceRequirements` presence/absence via boto3
- [ ] Test only registers the task definition — does not launch GPU instances (cheap and fast)