### PR TITLE
fix: encrypt pod root EBS volumes (bump website-pod to 6.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Apache 2.0 - see [LICENSE](LICENSE) for details.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_ecr_image_tagger"></a> [ecr\_image\_tagger](#module\_ecr\_image\_tagger) | registry.infrahouse.com/infrahouse/lambda-monitored/aws | 1.1.1 |
-| <a name="module_pod"></a> [pod](#module\_pod) | registry.infrahouse.com/infrahouse/website-pod/aws | 6.0.1 |
+| <a name="module_pod"></a> [pod](#module\_pod) | registry.infrahouse.com/infrahouse/website-pod/aws | 6.2.0 |
 | <a name="module_tcp-pod"></a> [tcp-pod](#module\_tcp-pod) | registry.infrahouse.com/infrahouse/tcp-pod/aws | 0.6.0 |
 
 ## Resources

--- a/website-pod.tf
+++ b/website-pod.tf
@@ -1,7 +1,7 @@
 module "pod" {
   count   = var.lb_type == "alb" ? 1 : 0
   source  = "registry.infrahouse.com/infrahouse/website-pod/aws"
-  version = "6.0.1"
+  version = "6.2.0"
   providers = {
     aws     = aws
     aws.dns = aws.dns


### PR DESCRIPTION
## Summary

Bumps the `website-pod` sub-module pin in `website-pod.tf` from `6.0.1` to `6.2.0`. website-pod 6.2.0 hardcodes `encrypted = true` on the launch template root EBS volume (using the account `aws/ebs` managed key), so EC2 instances created via this module no longer have **unencrypted root volumes** in accounts where "EBS encryption by default" is off.

Per issue #160, no new variables are added — encryption is unconditional, with no `*_encrypted` toggle or CMK passthrough.

## Behavioral change

Defaulting to encrypted is a behavioral change. Encryption applies at instance launch, so existing instances are unaffected until an instance refresh / ASG roll replaces them. Worth a changelog note and an appropriate version bump.

## Scope

- ✅ **website-pod** — bumped to 6.2.0 (this PR). This is the substantive fix and does not depend on tcp-pod.
- ⏳ **tcp-pod** — same gap exists, tracked separately in infrahouse/terraform-aws-tcp-pod#31. Once tcp-pod ships the fix, the `tcp-pod.tf` pin here should be bumped in a follow-up. Intentionally **not** included so it doesn't hold up the website-pod fix.

Refs #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)