### PR TITLE
feat: add extra_containers for ECS task sidecar support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,60 +58,63 @@ resource "aws_ecs_cluster" "ecs" {
 resource "aws_ecs_task_definition" "ecs" {
   family = var.service_name
   container_definitions = jsonencode(
-    [
-      merge(
-        {
-          name      = var.service_name
-          image     = var.docker_image
-          cpu       = var.container_cpu
-          memory    = var.container_memory
-          essential = true
-          portMappings = concat(
-            [
-              {
-                containerPort = var.container_port
-              }
-            ],
-            [
-              for k, v in var.extra_target_groups : {
-                containerPort = v.container_port
+    concat(
+      [
+        merge(
+          {
+            name      = var.service_name
+            image     = var.docker_image
+            cpu       = var.container_cpu
+            memory    = var.container_memory
+            essential = true
+            portMappings = concat(
+              [
+                {
+                  containerPort = var.container_port
+                }
+              ],
+              [
+                for k, v in var.extra_target_groups : {
+                  containerPort = v.container_port
+                }
+              ]
+            )
+            logConfiguration = local.log_configuration
+            environment      = var.task_environment_variables
+            secrets          = var.task_secrets
+            mountPoints = [
+              for name, def in merge(var.task_efs_volumes, var.task_local_volumes) : {
+                sourceVolume : name
+                containerPath : def.container_path
               }
             ]
-          )
-          logConfiguration = local.log_configuration
-          environment      = var.task_environment_variables
-          secrets          = var.task_secrets
-          mountPoints = [
-            for name, def in merge(var.task_efs_volumes, var.task_local_volumes) : {
-              sourceVolume : name
-              containerPath : def.container_path
+          },
+          var.container_command != null ? { command : var.container_command } : {},
+          var.dockerSecurityOptions != null ? { dockerSecurityOptions : var.dockerSecurityOptions } : {},
+          var.container_memory_reservation != null ? { memoryReservation : var.container_memory_reservation } : {},
+          var.container_healthcheck_command != null ? {
+            healthCheck = {
+              "retries" : 3,
+              "command" : [
+                "CMD-SHELL", var.container_healthcheck_command
+              ],
+              "timeout" : 5,
+              "interval" : 30,
+              "startPeriod" : null
             }
-          ]
-        },
-        var.container_command != null ? { command : var.container_command } : {},
-        var.dockerSecurityOptions != null ? { dockerSecurityOptions : var.dockerSecurityOptions } : {},
-        var.container_memory_reservation != null ? { memoryReservation : var.container_memory_reservation } : {},
-        var.container_healthcheck_command != null ? {
-          healthCheck = {
-            "retries" : 3,
-            "command" : [
-              "CMD-SHELL", var.container_healthcheck_command
-            ],
-            "timeout" : 5,
-            "interval" : 30,
-            "startPeriod" : null
-          }
-        } : {},
-        var.gpu_count > 0 ? {
-          resourceRequirements = [
-            {
-              type  = "GPU"
-              value = tostring(var.gpu_count)
-            }
-          ]
-        } : {}
-      )
-    ]
+          } : {},
+          var.gpu_count > 0 ? {
+            resourceRequirements = [
+              {
+                type  = "GPU"
+                value = tostring(var.gpu_count)
+              }
+            ]
+          } : {}
+        )
+      ],
+      var.extra_containers
+    )
   )
   execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
   task_role_arn      = var.task_role_arn

--- a/variables.tf
+++ b/variables.tf
@@ -519,6 +519,24 @@ variable "environment" {
   default     = "development"
 }
 
+variable "extra_containers" {
+  description = <<-EOT
+    Additional container definitions to include in the ECS task definition.
+    Each element is a map representing a full ECS container definition
+    (name, image, cpu, memory, etc.).  The primary application container
+    is always the first element; extra containers are appended after it.
+
+    Typical use-cases: ADOT/OpenTelemetry collector sidecars, DCGM
+    exporter for GPU metrics, log forwarders, or any helper container
+    that must share the task network namespace with the application.
+
+    Default is empty, which preserves the existing single-container
+    behaviour.
+  EOT
+  type        = list(any)
+  default     = []
+}
+
 variable "extra_files" {
   description = "Additional files to create on a host EC2 instance."
   type = list(


### PR DESCRIPTION
## Summary

Adds support for additional ECS task containers so users can run sidecars such as:
- AWS Distro for OpenTelemetry (ADOT) Collector
- NVIDIA dcgm-exporter for GPU metrics
- Log/metrics helper containers

This is needed for same-task scraping patterns such as:
`vLLM container :8000/metrics → ADOT sidecar → AMP remote_write`

## Design

- Adds a new `extra_containers` variable (`list(any)`, default `[]`)
- Wraps `container_definitions` in `concat([primary_container], var.extra_containers)`
- The primary application container remains the first element; extra containers are appended after it
- Keeps the default behaviour unchanged when the variable is empty

## Backward compatibility

Default is `[]`, so existing users get the same single-container task definition. No breaking changes.

## Testing

Local checks run:
- `terraform fmt -check -recursive` (passed)

Not run:
- `make test-clean`, because full AWS-backed tests require an InfraHouse-trusted IAM role and cannot run from my fork PR.

**Maintainer note:** CI may need to be run from an in-repo branch, as happened on previous PRs.
