### PR TITLE
fix(ecr_image_tagger): pin cryptography >= 48.0.1 for GHSA-537c-gmf6-5ccf

### DIFF
--- a/assets/ecr_image_tagger/requirements.txt
+++ b/assets/ecr_image_tagger/requirements.txt
@@ -1,1 +1,5 @@
 infrahouse-core ~= 0.26, >= 0.26.1
+# Security floor only: cryptography is an unused transitive dep
+# (infrahouse-core -> PyGithub -> pyjwt[crypto]). Pin >= 48.0.1 to clear
+# GHSA-537c-gmf6-5ccf. No API dependency, so no ~= upper cap.
+cryptography >= 48.0.1


### PR DESCRIPTION
## What

Pin `cryptography >= 48.0.1` in `assets/ecr_image_tagger/requirements.txt` to clear [GHSA-537c-gmf6-5ccf](https://github.com/advisories/GHSA-537c-gmf6-5ccf).

## Why

`cryptography` reaches the `ecr_image_tagger` Lambda as an **unused transitive dependency**:

```
infrahouse-core → PyGithub → pyjwt[crypto] → cryptography
```

Wheels `<= 48.0.0` statically link a vulnerable OpenSSL (out-of-bounds read, CVSS 7.5, availability), fixed in `48.0.1`.

The Lambda's runtime path is boto3-only (`ECRRepository`, `ECSService`, `ECSTaskDefinition`) and never invokes `cryptography`, so real exploit risk is effectively nil — but the packaged bundle still trips the `vuln-scanner-pr` workflow. This pin clears the advisory.

## Pin choice

Floor-only (`>= 48.0.1`), **not** a `~= 48.0` compatible-release pin: we don't code against cryptography's API (it's a transitive we never import), so the only real requirement is "at least the version with the OpenSSL fix." A floor-only constraint also lets pip satisfy whatever `PyGithub`/`pyjwt` need without manufacturing a resolution conflict. A comment in the file records this reasoning.

## Testing

Python-deps-only change to the Lambda bundle; no Terraform touched. Coverage comes from the security scanner confirming the advisory clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)