### PR TITLE
feat: add Prometheus metric scraping to CloudWatch agent daemon

### DIFF
--- a/assets/cloudwatch_agent_prometheus_config.tftmpl
+++ b/assets/cloudwatch_agent_prometheus_config.tftmpl
@@ -1,0 +1,79 @@
+${jsonencode({
+  "agent" = {
+    "logfile" = "/var/log/amazon-cloudwatch-agent.log"
+    "debug"   = false
+  }
+  "logs" = {
+    "logs_collected" = {
+      "files" = {
+        "collect_list" = [
+          {
+            "file_path"       = "/var/log/messages"
+            "log_group_name"  = syslog_group_name
+            "log_stream_name" = "{local_hostname}"
+          },
+          {
+            "file_path"       = "/var/log/dmesg"
+            "log_group_name"  = dmesg_group_name
+            "log_stream_name" = "{local_hostname}"
+          }
+        ]
+      }
+    }
+    "metrics_collected" = {
+      "prometheus" = {
+        "cluster_name"           = cluster_name
+        "prometheus_config_path" = "env:PROMETHEUS_CONFIG_CONTENT"
+        "ecs_service_discovery" = {
+          "sd_frequency"         = "1m"
+          "sd_result_file"       = "/tmp/cwagent_ecs_auto_sd.yaml"
+          "sd_cluster_region"    = aws_region
+          "sd_target_cluster"    = cluster_name
+          "docker_label"         = {}
+          "task_definition_list" = [
+            for target in prometheus_targets : {
+              "sd_job_name"             = target.job_name
+              "sd_metrics_path"         = target.metrics_path
+              "sd_metrics_ports"        = tostring(target.container_port)
+              "sd_task_definition_arn_pattern" = ".*"
+            }
+          ]
+        }
+        "emf_processor" = {
+          "metric_declaration" = [
+            for target in prometheus_targets : {
+              "source_labels"    = ["job"]
+              "label_matcher"    = target.job_name
+              "dimensions"       = [["ClusterName", "TaskDefinitionFamily"]]
+              "metric_selectors" = [".*"]
+            }
+          ]
+        }
+      }
+    }
+  }
+  "metrics" = {
+    "namespace" = "ECS/${cluster_name}"
+    "metrics_collected" = {
+      "cpu" = {
+        "measurement"                = ["cpu_usage_idle", "cpu_usage_iowait", "cpu_usage_user", "cpu_usage_system"]
+        "metrics_collection_interval" = 60
+        "totalcpu"                    = true
+      }
+      "mem" = {
+        "measurement"                = ["mem_used_percent", "mem_available", "mem_total"]
+        "metrics_collection_interval" = 60
+      }
+      "disk" = {
+        "measurement"                = ["used_percent", "inodes_free"]
+        "metrics_collection_interval" = 60
+        "resources"                   = ["*"]
+      }
+      "diskio" = {
+        "measurement"                = ["io_time", "read_bytes", "write_bytes"]
+        "metrics_collection_interval" = 60
+        "resources"                   = ["*"]
+      }
+    }
+  }
+})}

--- a/cloudwatch_agent.tf
+++ b/cloudwatch_agent.tf
@@ -55,6 +55,25 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_execution_policy" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+data "aws_iam_policy_document" "prometheus_ecs_sd" {
+  count = var.enable_cloudwatch_logs && length(var.cloudwatch_prometheus_scrape_targets) > 0 ? 1 : 0
+  statement {
+    actions = [
+      "ecs:ListTasks",
+      "ecs:DescribeTaskDefinition",
+      "ecs:DescribeContainerInstances",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "cloudwatch_agent_prometheus_sd" {
+  count  = var.enable_cloudwatch_logs && length(var.cloudwatch_prometheus_scrape_targets) > 0 ? 1 : 0
+  name   = "prometheus-ecs-service-discovery"
+  role   = aws_iam_role.cloudwatch_agent_task_role[0].id
+  policy = data.aws_iam_policy_document.prometheus_ecs_sd[0].json
+}
+
 resource "aws_ecs_task_definition" "cloudwatch_agent" {
   count              = var.enable_cloudwatch_logs ? 1 : 0
   family             = format("%s-cw-agent-daemon", var.service_name)
@@ -63,24 +82,34 @@ resource "aws_ecs_task_definition" "cloudwatch_agent" {
 
   container_definitions = jsonencode(
     [
-      {
-        name      = "cloudwatch-agent"
-        image     = var.cloudwatch_agent_image
-        memory    = local.cloudwatch_agent_container_resources.memory
-        cpu       = local.cloudwatch_agent_container_resources.cpu
-        essential = true
-        mountPoints = [
-          {
-            sourceVolume  = "log-volume"
-            containerPath = "/var/log"
-          },
-          {
-            sourceVolume  = "config-volume"
-            containerPath = "/etc/cwagentconfig"
-            readOnly      = true
-          }
-        ]
-      }
+      merge(
+        {
+          name      = "cloudwatch-agent"
+          image     = var.cloudwatch_agent_image
+          memory    = local.cloudwatch_agent_container_resources.memory
+          cpu       = local.cloudwatch_agent_container_resources.cpu
+          essential = true
+          mountPoints = [
+            {
+              sourceVolume  = "log-volume"
+              containerPath = "/var/log"
+            },
+            {
+              sourceVolume  = "config-volume"
+              containerPath = "/etc/cwagentconfig"
+              readOnly      = true
+            }
+          ]
+        },
+        length(var.cloudwatch_prometheus_scrape_targets) > 0 ? {
+          environment = [
+            {
+              name  = "PROMETHEUS_CONFIG_CONTENT"
+              value = local.prometheus_scrape_config
+            }
+          ]
+        } : {}
+      )
     ]
   )
 

--- a/datasources.tf
+++ b/datasources.tf
@@ -81,12 +81,25 @@ data "cloudinit_config" "ecs" {
                   {
                     path : local.cloudwatch_agent_config_path
                     permissions : "0644"
-                    content : templatefile(
-                      "${path.module}/assets/cloudwatch_agent_config.tftmpl",
-                      {
-                        syslog_group_name : aws_cloudwatch_log_group.ecs_ec2_syslog[0].name
-                        dmesg_group_name : aws_cloudwatch_log_group.ecs_ec2_dmesg[0].name
-                      }
+                    content : var.cloudwatch_agent_config != null ? var.cloudwatch_agent_config : (
+                      length(var.cloudwatch_prometheus_scrape_targets) > 0
+                      ? templatefile(
+                        "${path.module}/assets/cloudwatch_agent_prometheus_config.tftmpl",
+                        {
+                          syslog_group_name  = aws_cloudwatch_log_group.ecs_ec2_syslog[0].name
+                          dmesg_group_name   = aws_cloudwatch_log_group.ecs_ec2_dmesg[0].name
+                          prometheus_targets = var.cloudwatch_prometheus_scrape_targets
+                          cluster_name       = var.service_name
+                          aws_region         = data.aws_region.current.name
+                        }
+                      )
+                      : templatefile(
+                        "${path.module}/assets/cloudwatch_agent_config.tftmpl",
+                        {
+                          syslog_group_name = aws_cloudwatch_log_group.ecs_ec2_syslog[0].name
+                          dmesg_group_name  = aws_cloudwatch_log_group.ecs_ec2_dmesg[0].name
+                        }
+                      )
                     )
                   }
                 ] : [],

--- a/locals.tf
+++ b/locals.tf
@@ -96,6 +96,32 @@ locals {
     memory = 256
   }
 
+  # The CloudWatch agent's ECS service discovery writes discovered targets to
+  # sd_result_file (/tmp/cwagent_ecs_auto_sd.yaml) already carrying their job,
+  # TaskDefinitionFamily, container_name, and __metrics_path__ labels. Prometheus
+  # consumes that file via file_sd_configs. This is the canonical single-job
+  # pattern from the AWS docs: per-target job names and metrics paths come from
+  # the ecs_service_discovery config (sd_job_name / sd_metrics_path), not from
+  # separate scrape_configs, so one file_sd job covers every target.
+  # See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Setup-autodiscovery-ecs.html
+  prometheus_scrape_config = length(var.cloudwatch_prometheus_scrape_targets) > 0 ? yamlencode({
+    global = {
+      scrape_interval = "1m"
+      scrape_timeout  = "10s"
+    }
+    scrape_configs = [
+      {
+        job_name     = "cwagent-ecs-file-sd-config"
+        sample_limit = 10000
+        file_sd_configs = [
+          {
+            files = ["/tmp/cwagent_ecs_auto_sd.yaml"]
+          }
+        ]
+      }
+    ]
+  }) : ""
+
   vector_agent_config_path = "/etc/vector/vector.yaml"
   vector_agent_container_resources = {
     cpu    = 128

--- a/variables.tf
+++ b/variables.tf
@@ -213,6 +213,56 @@ variable "cloudwatch_agent_image" {
   default     = "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300062.0b1304"
 }
 
+variable "cloudwatch_agent_config" {
+  description = <<-EOT
+    Custom CloudWatch agent JSON config. When provided, replaces the
+    built-in default config template entirely.
+
+    The default template collects host logs (/var/log/messages, /var/log/dmesg)
+    and, when cloudwatch_prometheus_scrape_targets is non-empty, adds host
+    metrics and Prometheus scraping via ECS service discovery.
+
+    Example:
+      cloudwatch_agent_config = templatefile("files/cwagent.json.tftpl", { ... })
+  EOT
+  type        = string
+  default     = null
+}
+
+variable "cloudwatch_prometheus_scrape_targets" {
+  description = <<-EOT
+    Prometheus-style scrape targets for the CloudWatch agent daemon.
+
+    When non-empty, the CloudWatch agent daemon discovers matching ECS tasks by
+    task-definition ARN and container port (ECS service discovery), scrapes their
+    metrics endpoint, and publishes the metrics to CloudWatch (EMF) in the
+    ECS/ContainerInsights/Prometheus namespace, dimensioned by ClusterName and
+    TaskDefinitionFamily. The daemon also begins collecting host metrics
+    (CPU, memory, disk) into the ECS/{service_name} namespace.
+
+    When empty (default), the rendered config is byte-identical to the existing
+    logs-only behavior, so existing consumers see no change.
+
+    Each target's container_port is the port the app exposes its metrics on
+    (e.g. vLLM's OpenAI API + /metrics on 8000).
+
+    Example (vLLM):
+      cloudwatch_prometheus_scrape_targets = [
+        {
+          job_name       = "vllm"
+          metrics_path   = "/metrics"
+          container_port = 8000
+        }
+      ]
+  EOT
+  type = list(object({
+    job_name       = string
+    metrics_path   = optional(string, "/metrics")
+    container_port = number
+  }))
+  default = []
+}
+
 variable "cloudwatch_log_group" {
   description = <<-EOT
     CloudWatch log group name to create and use.


### PR DESCRIPTION
## What

Adds **opt-in Prometheus metric scraping** to the CloudWatch agent daemon. When a
consumer sets `cloudwatch_prometheus_scrape_targets`, the daemon discovers matching
ECS tasks (by task-definition + container port via ECS service discovery), scrapes
their `/metrics` endpoint, and publishes the metrics to CloudWatch as EMF.

## Why

GPU/LLM serving (e.g. vLLM) can't be autoscaled on CPU or raw GPU utilization — the
useful saturation signals live in the app's own Prometheus metrics
(`vllm:gpu_cache_usage_perc`, `vllm:num_requests_waiting`). Getting those into
CloudWatch lets a consumer attach an Application Auto Scaling **custom-metric** policy
to the ECS service, and feeds Grafana dashboards — without adding a separate sidecar
(reuses the daemon that's already running when `enable_cloudwatch_logs = true`).

## Design (mirrors the `vector_agent` opt-in pattern)

- **`cloudwatch_prometheus_scrape_targets`** — typed list of
  `{ job_name, metrics_path, container_port }`. Drives ECS service discovery +
  EMF export to `ECS/ContainerInsights/Prometheus` (dims: `ClusterName`,
  `TaskDefinitionFamily`), plus host CPU/mem/disk to `ECS/{service_name}`.
- **`cloudwatch_agent_config`** — raw-JSON override escape hatch (replaces the
  built-in template entirely, same as `vector_agent_config`).
- **Conditional ECS-SD IAM** (`ecs:ListTasks`, `DescribeTaskDefinition`,
  `DescribeContainerInstances`), gated on targets being non-empty.
- The scrape config reaches the agent via the `PROMETHEUS_CONFIG_CONTENT` env var and
  consumes the ECS-SD result file (`/tmp/cwagent_ecs_auto_sd.yaml`) through
  `file_sd_configs` — the canonical single-job pattern from the
  [AWS ECS autodiscovery docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Setup-autodiscovery-ecs.html).

## Backward compatibility

When `cloudwatch_prometheus_scrape_targets` is empty (default), the rendered agent
config is **byte-identical** to the previous logs-only output — no IAM, no userdata
diff, no plan changes for existing consumers.

## Test plan

- [x] `terraform fmt -check -recursive` clean
- [x] `terraform validate` (via `test_data/httpd`) passes
- [x] Rendered `cloudwatch_agent_prometheus_config.tftmpl` with a sample vLLM target →
      **valid JSON**; `prometheus_config_path = env:PROMETHEUS_CONFIG_CONTENT`,
      `sd_result_file = /tmp/cwagent_ecs_auto_sd.yaml`, EMF dims
      `[ClusterName, TaskDefinitionFamily]`
- [x] Rendered `PROMETHEUS_CONFIG_CONTENT` scrape YAML → valid; `file_sd_configs`
      points at the `sd_result_file`
- [ ] **Live integration test on real AWS** (GPU task exposing `/metrics`): confirm
      metrics land in `ECS/ContainerInsights/Prometheus` and drive a target-tracking
      policy. Not run here (needs GPU infra) — to be validated in sandbox before merge.

## Notes / follow-ups

- **Docker-label discovery** (`docker_labels` + `ECS_PROMETHEUS_EXPORTER_PORT`) is
  intentionally **not** in this PR to keep it independent of the open `extra_containers`
  PR (#163, which owns `main.tf`). Task-definition + port discovery already covers the
  single-service case; docker-label discovery can be a small follow-up.
- Discovery uses `sd_task_definition_arn_pattern = ".*"` filtered by
  `sd_metrics_ports` — fine for a dedicated single-service cluster; a tighter pattern
  could be exposed later if multiple services share a cluster and port.
